### PR TITLE
Only fix multiline text if no <tspan>'s present.

### DIFF
--- a/src/svg-renderer.js
+++ b/src/svg-renderer.js
@@ -148,8 +148,9 @@ class SvgRenderer {
             const font = textElement.getAttribute('font-family');
             fontsNeeded[font] = true;
             // Fix line breaks in text, which are not natively supported by SVG.
+            // Only fix if text does not have child tspans.
             let text = textElement.textContent;
-            if (text) {
+            if (text && textElement.childElementCount === 0) {
                 textElement.textContent = '';
                 const lines = text.split('\n');
                 text = '';


### PR DESCRIPTION
### Resolves

_What Github issue does this resolve (please include link)?_

Fixes issues with importing SVGs with text that already uses `<tspan>`'s to show multi-line text. The svg renderer currently assumes all SVGs just use bare `<text>firstline\nsecondline</text>`. But I'm trying to make the SVGs produced by scratch 3 to be spec compliant, so am baking that multiline export into there. 

The core problem with using the current method is that calling `.textContent` on a structure like 
```
<text>
    <tspan>hello</tspan>
    <tspan>world</tspan>
</text>
```
produces `helloworld` instead of the desired `hello\nworld`.

Basically: don't overfix SVG files!
