### PR TITLE
Break transformText into new functions that can be exported

### DIFF
--- a/src/font-converter.js
+++ b/src/font-converter.js
@@ -22,15 +22,13 @@ const convertFonts = function (svgTag) {
     // If there's an old font-family, switch to the new one.
     for (const textElement of textElements) {
         if (textElement.getAttribute('font-family') === 'Helvetica') {
-            textElement.setAttribute('font-family', 'Typey McTypeface');
+            textElement.setAttribute('font-family', 'Sans Serif');
         } else if (textElement.getAttribute('font-family') === 'Mystery') {
-            textElement.setAttribute('font-family', 'Griffy McGriffface');
-        } else if (textElement.getAttribute('font-family') === 'Marker') {
-            textElement.setAttribute('font-family', 'Knewey McKneeface');
+            textElement.setAttribute('font-family', 'Curly');
         } else if (textElement.getAttribute('font-family') === 'Gloria') {
-            textElement.setAttribute('font-family', 'Handlee McHandface');
+            textElement.setAttribute('font-family', 'Handwriting');
         } else if (textElement.getAttribute('font-family') === 'Donegal') {
-            textElement.setAttribute('font-family', 'Seriffy McSerifface');
+            textElement.setAttribute('font-family', 'Serif');
         }
     }
 };

--- a/src/font-converter.js
+++ b/src/font-converter.js
@@ -1,0 +1,38 @@
+/**
+ * @fileOverview Convert 2.0 fonts to 3.0 fonts.
+ */
+
+/**
+ * Given an SVG, replace Scratch 2.0 fonts with new 3.0 fonts. Add defaults where there are none.
+ * @param {SVGElement} svgTag The SVG dom object
+ * @return {void}
+ */
+const convertFonts = function (svgTag) {
+    // Collect all text elements into a list.
+    const textElements = [];
+    const collectText = domElement => {
+        if (domElement.localName === 'text') {
+            textElements.push(domElement);
+        }
+        for (let i = 0; i < domElement.childNodes.length; i++) {
+            collectText(domElement.childNodes[i]);
+        }
+    };
+    collectText(svgTag);
+    // If there's an old font-family, switch to the new one.
+    for (const textElement of textElements) {
+        if (textElement.getAttribute('font-family') === 'Helvetica') {
+            textElement.setAttribute('font-family', 'Typey McTypeface');
+        } else if (textElement.getAttribute('font-family') === 'Mystery') {
+            textElement.setAttribute('font-family', 'Griffy McGriffface');
+        } else if (textElement.getAttribute('font-family') === 'Marker') {
+            textElement.setAttribute('font-family', 'Knewey McKneeface');
+        } else if (textElement.getAttribute('font-family') === 'Gloria') {
+            textElement.setAttribute('font-family', 'Handlee McHandface');
+        } else if (textElement.getAttribute('font-family') === 'Donegal') {
+            textElement.setAttribute('font-family', 'Seriffy McSerifface');
+        }
+    }
+};
+
+module.exports = convertFonts;

--- a/src/font-inliner.js
+++ b/src/font-inliner.js
@@ -29,23 +29,17 @@ const createSVGElement = function (tagName) {
  * @return {void}
  */
 const inlineSvgFonts = function (svgTag) {
-    // Collect all text elements into a list.
-    const textElements = [];
-    const collectText = domElement => {
-        if (domElement.localName === 'text') {
-            textElements.push(domElement);
-        }
-        for (let i = 0; i < domElement.childNodes.length; i++) {
-            collectText(domElement.childNodes[i]);
-        }
-    };
-    collectText(svgTag);
     // Collect fonts that need injection.
     const fontsNeeded = {};
-    for (const textElement of textElements) {
-        const font = textElement.getAttribute('font-family');
-        fontsNeeded[font] = true;
-    }
+    const collectFonts = function collectFonts (domElement) {
+        if (domElement.getAttribute && domElement.getAttribute('font-family')) {
+            fontsNeeded[domElement.getAttribute('font-family')] = true;
+        }
+        for (let i = 0; i < domElement.children.length; i++) {
+            collectFonts(domElement.children[i]);
+        }
+    };
+    collectFonts(svgTag);
     const newDefs = createSVGElement('defs');
     const newStyle = createSVGElement('style');
     const allFonts = Object.keys(fontsNeeded);

--- a/src/font-inliner.js
+++ b/src/font-inliner.js
@@ -1,7 +1,7 @@
 /**
  * @fileOverview Import bitmap data into Scratch 3.0, resizing image as necessary.
  */
-import {FONTS} from 'scratch-render-fonts';
+const {FONTS} = require('scratch-render-fonts');
 
 /**
  * Helper to create an SVG element with the correct NS.

--- a/src/font-inliner.js
+++ b/src/font-inliner.js
@@ -30,10 +30,10 @@ const createSVGElement = function (tagName) {
  */
 const inlineSvgFonts = function (svgTag) {
     // Collect fonts that need injection.
-    const fontsNeeded = {};
+    const fontsNeeded = new Set();
     const collectFonts = function collectFonts (domElement) {
         if (domElement.getAttribute && domElement.getAttribute('font-family')) {
-            fontsNeeded[domElement.getAttribute('font-family')] = true;
+            fontsNeeded.add(domElement.getAttribute('font-family'));
         }
         for (let i = 0; i < domElement.children.length; i++) {
             collectFonts(domElement.children[i]);
@@ -42,8 +42,7 @@ const inlineSvgFonts = function (svgTag) {
     collectFonts(svgTag);
     const newDefs = createSVGElement('defs');
     const newStyle = createSVGElement('style');
-    const allFonts = Object.keys(fontsNeeded);
-    for (const font of allFonts) {
+    for (const font of fontsNeeded) {
         if (FONTS.hasOwnProperty(font)) {
             newStyle.textContent += FONTS[font];
         }

--- a/src/index.js
+++ b/src/index.js
@@ -1,10 +1,14 @@
 const importBitmap = require('./bitmap-importer');
 const SVGRenderer = require('./svg-renderer');
+const {inlineSvgFonts} = require('./font-inliner');
+const convertFonts = require('./font-converter');
 // /**
 //  * Export for NPM & Node.js
 //  * @type {RenderWebGL}
 //  */
 module.exports = {
-    SVGRenderer: SVGRenderer,
-    importBitmap: importBitmap
+    convertFonts: convertFonts,
+    inlineSvgFonts: inlineSvgFonts,
+    importBitmap: importBitmap,
+    SVGRenderer: SVGRenderer
 };

--- a/src/svg-renderer.js
+++ b/src/svg-renderer.js
@@ -1,5 +1,5 @@
-import {createSVGElement, inlineSvgFonts} from './font-inliner';
-import convertFonts from './font-converter';
+const {createSVGElement, inlineSvgFonts} = require('./font-inliner');
+const convertFonts = require('./font-converter');
 
 /**
  * Main quirks-mode SVG rendering code.

--- a/src/svg-renderer.js
+++ b/src/svg-renderer.js
@@ -34,7 +34,7 @@ class SvgRenderer {
      * @param {Function} [onFinish] Optional callback for when drawing finished.
      */
     fromString (svgString, scale, onFinish) {
-        this._loadString(svgString);
+        this.loadString(svgString);
         this._draw(scale, onFinish);
     }
 
@@ -44,7 +44,7 @@ class SvgRenderer {
      * @return {object} the natural size, in Scratch units, of this SVG.
      */
     measure (svgString) {
-        this._loadString(svgString);
+        this.loadString(svgString);
         return this._measurements;
     }
 
@@ -66,7 +66,7 @@ class SvgRenderer {
      * Load an SVG string and normalize it. All the steps before drawing/measuring.
      * @param {string} svgString String of SVG data to draw in quirks-mode.
      */
-    _loadString (svgString) {
+    loadString (svgString) {
         // New svg string invalidates the cached image
         this._cachedImage = null;
 
@@ -187,7 +187,7 @@ class SvgRenderer {
      */
     _transformMeasurements () {
         // Save `svgText` for later re-parsing.
-        const svgText = this._toString();
+        const svgText = this.toString();
 
         // Append the SVG dom to the document.
         // This allows us to use `getBBox` on the page,
@@ -238,7 +238,7 @@ class SvgRenderer {
      * Serialize the active SVG DOM to a string.
      * @returns {string} String representing current SVG data.
      */
-    _toString () {
+    toString () {
         const serializer = new XMLSerializer();
         return serializer.serializeToString(this._svgDom);
     }
@@ -272,7 +272,7 @@ class SvgRenderer {
                 this._cachedImage = img;
                 this._drawFromImage(scale, onFinish);
             };
-            const svgText = this._toString();
+            const svgText = this.toString();
             img.src = `data:image/svg+xml;utf8,${encodeURIComponent(svgText)}`;
         }
     }

--- a/src/svg-renderer.js
+++ b/src/svg-renderer.js
@@ -235,13 +235,13 @@ class SvgRenderer {
 
     /**
      * Serialize the active SVG DOM to a string.
-     * @param {?boolean} fontsInjected True if fonts should be included in the SVG as
+     * @param {?boolean} shouldInjectFonts True if fonts should be included in the SVG as
      *     base64 data.
      * @returns {string} String representing current SVG data.
      */
-    toString (fontsInjected) {
+    toString (shouldInjectFonts) {
         let svgDom = this._svgDom;
-        if (fontsInjected) {
+        if (shouldInjectFonts) {
             svgDom = this._svgDom.cloneNode(true /* deep */);
             inlineSvgFonts(svgDom.documentElement);
         }

--- a/src/svg-renderer.js
+++ b/src/svg-renderer.js
@@ -137,7 +137,6 @@ class SvgRenderer {
             }
         }
         convertFonts(this._svgTag);
-        inlineSvgFonts(this._svgTag);
     }
 
     /**
@@ -236,11 +235,19 @@ class SvgRenderer {
 
     /**
      * Serialize the active SVG DOM to a string.
+     * @param {?boolean} fontsInjected True if fonts should be included in the SVG as
+     *     base64 data.
      * @returns {string} String representing current SVG data.
      */
-    toString () {
+    toString (fontsInjected) {
+        let svgDom = this._svgDom;
+        if (fontsInjected) {
+            svgDom = this._svgDom.cloneNode(true /* deep */);
+            inlineSvgFonts(svgDom.documentElement);
+        }
         const serializer = new XMLSerializer();
-        return serializer.serializeToString(this._svgDom);
+        const string = serializer.serializeToString(svgDom);
+        return string;
     }
 
     /**
@@ -272,7 +279,7 @@ class SvgRenderer {
                 this._cachedImage = img;
                 this._drawFromImage(scale, onFinish);
             };
-            const svgText = this.toString();
+            const svgText = this.toString(true /* fontsInjected */);
             img.src = `data:image/svg+xml;utf8,${encodeURIComponent(svgText)}`;
         }
     }


### PR DESCRIPTION
Depends on https://github.com/LLK/scratch-render-fonts/pull/3
- Breaks apart transform text, and exposes some useful functions that will be used in the dependent PRs
- Adds convertFont, which converts 2.0 to 3.0 fonts.