### PR TITLE
Use src/index for browser entry point

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "description": "SVG renderer for Scratch",
   "main": "./dist/node/scratch-svg-renderer.js",
-  "browser": "./dist/web/scratch-svg-renderer.js",
+  "browser": "./src/index.js",
   "scripts": {
     "build": "npm run clean && webpack --progress --colors --bail",
     "clean": "rimraf ./dist",
@@ -20,22 +20,24 @@
     "type": "git",
     "url": "git+ssh://git@github.com/LLK/scratch-svg-renderer.git"
   },
+  "dependencies": {
+    "base64-loader": "1.0.0",
+    "jimp": "0.2.27",
+    "minilog": "3.1.0",
+    "scratch-render-fonts": "1.0.0-prerelease.20180524203748"
+  },
   "devDependencies": {
     "babel-core": "6.26.0",
     "babel-eslint": "^8.1.2",
     "babel-loader": "7.1.4",
     "babel-preset-env": "1.6.1",
-    "base64-loader": "1.0.0",
     "eslint": "^4.14.0",
     "eslint-config-scratch": "^5.0.0",
     "eslint-plugin-import": "^2.12.0",
-    "jimp": "0.2.27",
     "json": "^9.0.6",
     "lodash.defaultsdeep": "4.6.0",
-    "minilog": "3.1.0",
     "mkdirp": "^0.5.1",
     "rimraf": "^2.6.1",
-    "scratch-render-fonts": "1.0.0-prerelease.20180524203748",
     "webpack": "^4.8.0",
     "webpack-cli": "^2.0.15"
   }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -49,6 +49,10 @@ module.exports = [
             path: path.resolve('dist', 'node'),
             filename: '[name].js'
         },
+        externals: {
+            jimp: true,
+            minilog: true
+        },
         module: {
             rules: [{
                 options: {


### PR DESCRIPTION
### Proposed Changes

- Use src/index for browser entry point instead of webpack build library
- Depend on dependencies used in `src` as non-dev dependencies
- Build node version with non-dev dependencies as external modules

### Reason for Changes

Sibling of https://github.com/LLK/scratch-vm/pull/1106
