### PR TITLE
Build scratch-render-fonts using babel loader

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -9,7 +9,10 @@ const base = {
     },
     module: {
         rules: [{
-            include: path.resolve('src'),
+            include: [
+                path.resolve('src'),
+                path.resolve('node_modules', 'scratch-render-fonts')
+            ],
             test: /\.js$/,
             loader: 'babel-loader',
             options: {


### PR DESCRIPTION
Build the scratch-render-fonts file using the babel loader with the env presets to make sure the file is useable in other browsers. 

/cc @mzgoddard @fsih 