### PR TITLE
Fix the default line height. In 2.0 the default is 1

### DIFF
--- a/src/svg-renderer.js
+++ b/src/svg-renderer.js
@@ -143,7 +143,7 @@ class SvgRenderer {
                 for (const line of lines) {
                     const tspanNode = createSVGElement('tspan');
                     tspanNode.setAttribute('x', '0');
-                    tspanNode.setAttribute('dy', '1.2em');
+                    tspanNode.setAttribute('dy', '1em');
                     tspanNode.textContent = line;
                     textElement.appendChild(tspanNode);
                 }


### PR DESCRIPTION
### Resolves
Imported multiline text from 2.0 with no line height specified uses line height 1 in Scratch 2.0, but in 3.0 we have been changing it to 1.2.

### Proposed Changes
Fixes the line height given to text coming in from 2.0

### Reason for Changes
Make text better match 2.0

### Test Coverage
I tested using project 224888359