### PR TITLE
Font calibration

### DIFF
--- a/src/svg-renderer.js
+++ b/src/svg-renderer.js
@@ -136,6 +136,7 @@ class SvgRenderer {
             // Fix line breaks in text, which are not natively supported by SVG.
             // Only fix if text does not have child tspans.
             let text = textElement.textContent;
+            let firstTspan = true;
             if (text && textElement.childElementCount === 0) {
                 textElement.textContent = '';
                 const lines = text.split('\n');
@@ -143,13 +144,49 @@ class SvgRenderer {
                 for (const line of lines) {
                     const tspanNode = createSVGElement('tspan');
                     tspanNode.setAttribute('x', '0');
-                    tspanNode.setAttribute('dy', '1em');
+                    if (firstTspan) {
+                        tspanNode.setAttribute('dy', '0');
+                        firstTspan = false;
+                    }
+                    const mtx = textElement.transform.baseVal[0].matrix;
+                    const dx = .2;
+                    let dy = 0;
+                    if (textElement.getAttribute('font-family') === 'Gloria') {
+                        textElement.setAttribute('font-family', 'Handwriting');
+                        tspanNode.setAttribute('dy', '2em');
+                        dy = -1.2;
+                    } else if (textElement.getAttribute('font-family') === 'Scratch') {
+                        tspanNode.setAttribute('dy', '0.89em');
+                        dy = -.1;
+                    } else if (textElement.getAttribute('font-family') === 'Mystery') {
+                        textElement.setAttribute('font-family', 'Curly');
+                        tspanNode.setAttribute('dy', '1.38em');
+                        dy = -.5;
+                    } else if (textElement.getAttribute('font-family') === 'Marker') {
+                        tspanNode.setAttribute('dy', '1.45em');
+                        dy = -.5;
+                    } else if (textElement.getAttribute('font-family') === 'Helvetica') {
+                        textElement.setAttribute('font-family', 'Sans Serif');
+                        tspanNode.setAttribute('dy', '1.13em');
+                        dy = -.2;
+                    } else if (textElement.getAttribute('font-family') === 'Donegal') {
+                        textElement.setAttribute('font-family', 'Serif');
+                        tspanNode.setAttribute('dy', '1.25em');
+                        dy = -.3;
+                    } else {
+                        tspanNode.setAttribute('dy', '1.2em');
+                    }
+
+                    // Right multiply matrix by a translation of dy
+                    mtx.e += (mtx.b * dx) + (mtx.c * dy);
+                    mtx.e *= mtx.a;
+                    mtx.f += (mtx.a * dx) + (mtx.d * dy);
+                    mtx.f *= mtx.d;
                     tspanNode.textContent = line;
                     textElement.appendChild(tspanNode);
                 }
             }
         }
-        convertFonts(this._svgTag);
     }
 
     /**


### PR DESCRIPTION
### Resolves
Fixes https://github.com/LLK/scratch-paint/issues/479
Fixes https://github.com/LLK/scratch-paint/issues/442
2.0 renders text as if it has more padding around all edges, and this also significantly affects the line height

### Proposed Changes
- Simulate the padding around each line of text by changing the line spacing and translating the first line to the correct location in the scratch 2 conversion code

I wasn't able to figure out how to derive the offsets (I suspect part of it is that alignment-baseline=text-before-edge is not doing anything). They seem highly dependent on the font--for instance, Gloria shifts up while Scratch shifts down and to the left. Therefore I ended up hard-coding these offsets on a per-font basis.

Before: (Project 226299289 in Scratch 2 and 3 overlaid)
<img width="483" alt="font calibration before" src="https://user-images.githubusercontent.com/2855464/40729840-4d47df9c-63fb-11e8-9d39-dfb69ed878bb.png">
After:
<img width="483" alt="font calibration" src="https://user-images.githubusercontent.com/2855464/40729847-507bd5ba-63fb-11e8-829c-d31e16022b7e.png">

Before: (Project 226304687 in Scratch 2 and 3)
![image](https://user-images.githubusercontent.com/2855464/40730035-bc2b7c48-63fb-11e8-9b34-45614d7e3c93.png)
After:
![image](https://user-images.githubusercontent.com/2855464/40730095-e460a0d0-63fb-11e8-98d9-fe4d4f213f86.png)

### Reason for Changes

Compatibility

### Test Coverage
Tested projects 226299289, 226304687, 226490686, 219155892, 209781807