### PR TITLE
Use `getItem(0)` instead of `[0]` to support text parsing on Safari

### DIFF
--- a/src/svg-renderer.js
+++ b/src/svg-renderer.js
@@ -170,7 +170,7 @@ class SvgRenderer {
                 ty = -4 * fontSize / 22;
             }
             // Right multiply matrix by a translation of (tx, ty)
-            const mtx = textElement.transform.baseVal[0].matrix;
+            const mtx = textElement.transform.baseVal.getItem(0).matrix;
             mtx.e += (mtx.a * tx) + (mtx.c * ty);
             mtx.f += (mtx.b * tx) + (mtx.d * ty);
 


### PR DESCRIPTION
### Resolves

_What Github issue does this resolve (please include link)?_

Fixes https://github.com/LLK/scratch-gui/issues/2270

### Proposed Changes

_Describe what this Pull Request does_

Use `getItem` instead of array access. Chrome/Gecko added support for array like access for SVGTransformList a long time ago, but Safari never did because it isn't in the spec. 

https://developer.mozilla.org/en-US/docs/Web/API/SVGTransformList

### Test Coverage

_Please show how you have added tests to cover your changes_

Tested importing some projects that use text into Safari.
