### PR TITLE
Use childNodes instead of children to fix Edge

### DIFF
--- a/src/font-inliner.js
+++ b/src/font-inliner.js
@@ -35,8 +35,8 @@ const inlineSvgFonts = function (svgTag) {
         if (domElement.getAttribute && domElement.getAttribute('font-family')) {
             fontsNeeded.add(domElement.getAttribute('font-family'));
         }
-        for (let i = 0; i < domElement.children.length; i++) {
-            collectFonts(domElement.children[i]);
+        for (let i = 0; i < domElement.childNodes.length; i++) {
+            collectFonts(domElement.childNodes[i]);
         }
     };
     collectFonts(svgTag);


### PR DESCRIPTION
### Resolves

_What Github issue does this resolve (please include link)?_

Fixes https://github.com/LLK/scratch-gui/issues/2328

### Proposed Changes

_Describe what this Pull Request does_

Use `childNodes` instead of `children` when parsing XML. Similar fix to https://github.com/LLK/scratch-gui/issues/2328 which happened at an earlier point in a similar way.
