### PR TITLE
Use 18 instead of 14 when the font size is missing

### DIFF
--- a/src/font-converter.js
+++ b/src/font-converter.js
@@ -21,7 +21,9 @@ const convertFonts = function (svgTag) {
     collectText(svgTag);
     // If there's an old font-family, switch to the new one.
     for (const textElement of textElements) {
-        if (textElement.getAttribute('font-family') === 'Helvetica') {
+        // If there's no font-family provided, provide one.
+        if (!textElement.getAttribute('font-family') ||
+            textElement.getAttribute('font-family') === 'Helvetica') {
             textElement.setAttribute('font-family', 'Sans Serif');
         } else if (textElement.getAttribute('font-family') === 'Mystery') {
             textElement.setAttribute('font-family', 'Curly');

--- a/src/svg-renderer.js
+++ b/src/svg-renderer.js
@@ -130,10 +130,6 @@ class SvgRenderer {
             if (!textElement.getAttribute('font-size')) {
                 textElement.setAttribute('font-size', '18');
             }
-            // If there's no font-family provided, provide one.
-            if (!textElement.getAttribute('font-family')) {
-                textElement.setAttribute('font-family', 'Helvetica');
-            }
             let text = textElement.textContent;
 
             // Fix line breaks in text, which are not natively supported by SVG.

--- a/src/svg-renderer.js
+++ b/src/svg-renderer.js
@@ -128,7 +128,7 @@ class SvgRenderer {
             textElement.setAttribute('alignment-baseline', 'text-before-edge');
             // If there's no font size provided, provide one.
             if (!textElement.getAttribute('font-size')) {
-                textElement.setAttribute('font-size', '14');
+                textElement.setAttribute('font-size', '18');
             }
             // If there's no font-family provided, provide one.
             if (!textElement.getAttribute('font-family')) {


### PR DESCRIPTION
### Resolves
Fixes https://github.com/LLK/scratch-render/issues/215

### Proposed Changes
Switched the default font size when none is provided from 14 to 18. This matches the 2.0 font in height. (Some change is inevitable, due to the font conversion.) Here are the 2 projects overlapped, after the fix:
![image](https://user-images.githubusercontent.com/2855464/44229076-f0968d00-a164-11e8-98b7-6b44649cd07d.png)

### Reason for Changes
Better match 2.0

