### PR TITLE
reparse with svg xmlns if getBBox is missing

### DIFF
--- a/src/svg-renderer.js
+++ b/src/svg-renderer.js
@@ -72,6 +72,12 @@ class SvgRenderer {
         // New svg string invalidates the cached image
         this._cachedImage = null;
 
+        // Add root svg namespace if it does not exist.
+        const svgAttrs = svgString.match(/<svg [^>]*>/);
+        if (svgAttrs && svgAttrs[0].indexOf('xmlns=') === -1) {
+            svgString = svgString.replace('<svg ', '<svg xmlns="http://www.w3.org/2000/svg" ');
+        }
+
         // Parse string into SVG XML.
         const parser = new DOMParser();
         this._svgDom = parser.parseFromString(svgString, 'text/xml');


### PR DESCRIPTION
### Resolves

Fix https://github.com/LLK/scratch-vm/issues/1440

### Proposed Changes

Make sure that the svg tag is parsed with an xmlns attribute so it is an SVGSVGElement with a getBBox method.

### Reason for Changes

getBBox is provided by SVGGraphicsElement. For the SVG tag to be a
SVGSVGElement that subclasses SVGGraphicsElement and have a getBBox
method to determine the measurements of the svg the svg tag must have
its xmlns attribute set to the svg spec.

### Test Coverage

Load project 105250254 http://localhost:8601/#105250254
