### PR TITLE
ensure text element has an svg transform to manipulate

### DIFF
--- a/src/svg-renderer.js
+++ b/src/svg-renderer.js
@@ -165,6 +165,12 @@ class SvgRenderer {
                 spacing = 1.25;
                 ty = -4 * fontSize / 22;
             }
+
+            if (textElement.transform.baseVal.length === 0) {
+                const transform = this._svgTag.createSVGTransform();
+                textElement.transform.baseVal.appendItem(transform);
+            }
+
             // Right multiply matrix by a translation of (tx, ty)
             const mtx = textElement.transform.baseVal.getItem(0).matrix;
             mtx.e += (mtx.a * tx) + (mtx.c * ty);


### PR DESCRIPTION
### Resolves

Load a project with a non-transformed text element.

### Proposed Changes

Make sure the text element has an SVGTransform before fetching and modifying its SVGMatrix.

### Reason for Changes

Trying to get the SVGTransform without a transform in the list errors resulting in the svg not loading and later errors loading the full project.

### Test Coverage

Project 211917681 has such a text element. Try loading it in a local build: http://localhost:8601/#211917681
