### PR TITLE
Fix gradients

### DIFF
--- a/src/svg-renderer.js
+++ b/src/svg-renderer.js
@@ -89,6 +89,8 @@ class SvgRenderer {
         if (fromVersion2) {
             // Transform all text elements.
             this._transformText();
+            // Fix gradients
+            this._transformGradients();
             // Transform measurements.
             this._transformMeasurements();
         } else if (!this._svgTag.getAttribute('viewBox')) {
@@ -193,6 +195,30 @@ class SvgRenderer {
                     tspanNode.textContent = line;
                     textElement.appendChild(tspanNode);
                 }
+            }
+        }
+    }
+
+    /**
+     * Fix SVGs to comply with SVG spec. Scratch 2 defaults to x2 = 0 when x2 is missing, but
+     * SVG defaults to x2 = 1 when missing.
+     */
+    _transformGradients () {
+        // Collect all gradient elements into a list.
+        const linearGradientElements = [];
+        const collectElements = domElement => {
+            if (domElement.localName === 'linearGradient') {
+                linearGradientElements.push(domElement);
+            }
+            for (let i = 0; i < domElement.childNodes.length; i++) {
+                collectElements(domElement.childNodes[i]);
+            }
+        };
+        collectElements(this._svgTag);
+        // For each gradient element, supply x2 if necessary.
+        for (const gradientElement of linearGradientElements) {
+            if (!gradientElement.getAttribute('x2')) {
+                gradientElement.setAttribute('x2', '0');
             }
         }
     }


### PR DESCRIPTION
### Resolves
Fixes https://github.com/LLK/scratch-render/issues/236

### Proposed Changes
Fix exported Scratch 2.0 SVGs to match SVG spec

### Reason for Changes
Scratch 2.0 assumes that for linearGradient elements, x2 defaults to 0, but in the SVG spec x2 defaults to 100%

### Test Coverage
Tested several projects from the aforementioned bug
