### PR TITLE
Provide SVG width and height if they are missing

### DIFF
--- a/src/svg-renderer.js
+++ b/src/svg-renderer.js
@@ -97,6 +97,9 @@ class SvgRenderer {
         } else if (!this._svgTag.getAttribute('viewBox')) {
             // Renderer expects a view box.
             this._transformMeasurements();
+        } else if (!this._svgTag.getAttribute('width') || !this._svgTag.getAttribute('height')) {
+            this._svgTag.setAttribute('width', this._svgTag.viewBox.baseVal.width);
+            this._svgTag.setAttribute('height', this._svgTag.viewBox.baseVal.height);
         }
         this._measurements = {
             width: this._svgTag.viewBox.baseVal.width,


### PR DESCRIPTION
### Resolves
Fixes https://github.com/LLK/scratch-render/issues/333
Fixes https://github.com/LLK/scratch-paint/issues/753

### Proposed Changes
Provide width and height on SVG when it's missing.

### Reason for Changes
Renderer doesn't handle width and height as percents correctly on high dpi devices and zoomed browsers, and 100% is the default value

### Test Coverage

