### PR TITLE
Fix paren typo in the svg fixer, with test to make sure undefineds do…

### DIFF
--- a/src/fixup-svg-string.js
+++ b/src/fixup-svg-string.js
@@ -15,7 +15,7 @@ module.exports = function (svgString) {
     // DOMParser from crashing
     if (svgAttrs && svgAttrs[0].indexOf('&ns_') !== -1 && svgString.indexOf('<!DOCTYPE') === -1) {
         svgString = svgString.replace(svgAttrs[0],
-            svgAttrs[0].replace(/&ns_[^;]+;/g), 'http://ns.adobe.com/Extensibility/1.0/');
+            svgAttrs[0].replace(/&ns_[^;]+;/g, 'http://ns.adobe.com/Extensibility/1.0/'));
     }
 
     // The <metadata> element is not needed for rendering and sometimes contains

--- a/test/fixup-svg-string.js
+++ b/test/fixup-svg-string.js
@@ -20,6 +20,8 @@ test('fixupSvgString should make parsing fixtures not throw', t => {
         .toString();
     const fixed = fixupSvgString(svgString);
 
+    // Make sure undefineds aren't being written into the file
+    t.equal(fixed.indexOf('undefined'), -1);
     t.notThrow(() => {
         domParser.parseFromString(fixed, 'text/xml');
     });


### PR DESCRIPTION
Woops, paren error caused writing undefineds into the namespace instead of the real URL. 

This does not impact the images not loading in the paint editor, just thought it was worth fixing.