### PR TITLE
Handle a bug where early return didn't update fill and stroke width

### DIFF
--- a/src/transform-applier.js
+++ b/src/transform-applier.js
@@ -538,6 +538,8 @@ const transformStrokeWidths = function (svgTag, windowRef, bboxForTesting) {
             matrix = Matrix.compose(matrix, _parseTransform(element));
             if (Matrix.toString(matrix) === Matrix.toString(Matrix.identity())) {
                 element.removeAttribute('transform');
+                element.setAttribute('stroke-width', strokeWidth);
+                element.setAttribute('fill', fill);
                 return;
             }
 

--- a/test/test-output/transform-applier-test.html
+++ b/test/test-output/transform-applier-test.html
@@ -349,5 +349,25 @@
         </radialGradient></defs>
       <path id="path" fill="url(#grad_8-.75,0,-0.20096189432334202,0.75,0,0)" stroke="#003FFF" stroke-width="3.75" d="M 21.9615 30 A 25.6495 32.8953 -33.003 1 1 43.923 60 "/>
     </svg>
+        </div><p>blackFillsBugFix</p>
+        <div style="width: 500px; border-style: solid; border-width: 1px;">
+            <svg width="26px" height="14px" viewBox="0 0 26 14" version="1.1" xml:space="preserve" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      <g>
+        <g id="Page-1" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+          <path d="M23.87,0.75 C20.19,0.75 16.38,4.75 16.38,4.75 L16.38,9.25 C16.38,9.25 20.19,13.25 23.87,13.25
+              C24.6811343,11.269062 25.0661499,9.139551 25,7 C25.0661499,4.860449 24.6811343,2.73093802 23.87,0.75 Z"
+              id="Shape" stroke="#149948" stroke-width="0.8"/>
+        </g>
+      </g>
+    </svg>
+        </div>
+        <div style="width: 500px; border-style: solid; border-width: 0 1px 1px 1px;">
+            <svg width="26px" height="14px" viewBox="0 0 26 14" version="1.1" xml:space="preserve" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      <g>
+        <g id="Page-1" stroke="none" fill-rule="evenodd">
+          <path d="M23.87,0.75 C20.19,0.75 16.38,4.75 16.38,4.75 L16.38,9.25 C16.38,9.25 20.19,13.25 23.87,13.25&#xA;              C24.6811343,11.269062 25.0661499,9.139551 25,7 C25.0661499,4.860449 24.6811343,2.73093802 23.87,0.75 Z" id="Shape" stroke="#149948" stroke-width="0.8" fill="none"/>
+        </g>
+      </g>
+    </svg>
         </div>
 </body></html>

--- a/test/test-output/transform-applier-test.html
+++ b/test/test-output/transform-applier-test.html
@@ -353,10 +353,10 @@
         <div style="width: 500px; border-style: solid; border-width: 1px;">
             <svg width="26px" height="14px" viewBox="0 0 26 14" version="1.1" xml:space="preserve" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
       <g>
-        <g id="Page-1" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+        <g id="Page-1" stroke="none" stroke-width="5" fill="none" fill-rule="evenodd">
           <path d="M23.87,0.75 C20.19,0.75 16.38,4.75 16.38,4.75 L16.38,9.25 C16.38,9.25 20.19,13.25 23.87,13.25
               C24.6811343,11.269062 25.0661499,9.139551 25,7 C25.0661499,4.860449 24.6811343,2.73093802 23.87,0.75 Z"
-              id="Shape" stroke="#149948" stroke-width="0.8"/>
+              id="Shape" stroke="#149948"/>
         </g>
       </g>
     </svg>
@@ -365,7 +365,7 @@
             <svg width="26px" height="14px" viewBox="0 0 26 14" version="1.1" xml:space="preserve" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
       <g>
         <g id="Page-1" stroke="none" fill-rule="evenodd">
-          <path d="M23.87,0.75 C20.19,0.75 16.38,4.75 16.38,4.75 L16.38,9.25 C16.38,9.25 20.19,13.25 23.87,13.25&#xA;              C24.6811343,11.269062 25.0661499,9.139551 25,7 C25.0661499,4.860449 24.6811343,2.73093802 23.87,0.75 Z" id="Shape" stroke="#149948" stroke-width="0.8" fill="none"/>
+          <path d="M23.87,0.75 C20.19,0.75 16.38,4.75 16.38,4.75 L16.38,9.25 C16.38,9.25 20.19,13.25 23.87,13.25&#xA;              C24.6811343,11.269062 25.0661499,9.139551 25,7 C25.0661499,4.860449 24.6811343,2.73093802 23.87,0.75 Z" id="Shape" stroke="#149948" stroke-width="5" fill="none"/>
         </g>
       </g>
     </svg>

--- a/test/transform-applier.js
+++ b/test/transform-applier.js
@@ -767,4 +767,29 @@ test('userSpaceRadialGradientTransform', t => {
     t.end();
 });
 
+test('blackFillsBugFix', t => {
+    const svgString =
+    `<svg width="26px" height="14px" viewBox="0 0 26 14" version="1.1" xml:space="preserve" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      <g>
+        <g id="Page-1" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+          <path d="M23.87,0.75 C20.19,0.75 16.38,4.75 16.38,4.75 L16.38,9.25 C16.38,9.25 20.19,13.25 23.87,13.25
+              C24.6811343,11.269062 25.0661499,9.139551 25,7 C25.0661499,4.860449 24.6811343,2.73093802 23.87,0.75 Z"
+              id="Shape" stroke="#149948" stroke-width="0.8"/>
+        </g>
+      </g>
+    </svg>`;
+    const svgElement = parser.parseFromString(svgString, 'text/xml').documentElement;
+    transformStrokeWidths(svgElement, window,
+        {
+            height: 12.5,
+            width: 24.020904541015625,
+            x: 0.9896308183670044,
+            y: 0.75
+        });
+    comparisonFileAppend(svgString, svgElement, 'blackFillsBugFix');
+    t.equals('none', svgElement.getElementById('Shape').attributes.fill.value);
+
+    t.end();
+});
+
 outputComparisonFile();

--- a/test/transform-applier.js
+++ b/test/transform-applier.js
@@ -771,10 +771,10 @@ test('blackFillsBugFix', t => {
     const svgString =
     `<svg width="26px" height="14px" viewBox="0 0 26 14" version="1.1" xml:space="preserve" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
       <g>
-        <g id="Page-1" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+        <g id="Page-1" stroke="none" stroke-width="5" fill="none" fill-rule="evenodd">
           <path d="M23.87,0.75 C20.19,0.75 16.38,4.75 16.38,4.75 L16.38,9.25 C16.38,9.25 20.19,13.25 23.87,13.25
               C24.6811343,11.269062 25.0661499,9.139551 25,7 C25.0661499,4.860449 24.6811343,2.73093802 23.87,0.75 Z"
-              id="Shape" stroke="#149948" stroke-width="0.8"/>
+              id="Shape" stroke="#149948"/>
         </g>
       </g>
     </svg>`;
@@ -788,6 +788,7 @@ test('blackFillsBugFix', t => {
         });
     comparisonFileAppend(svgString, svgElement, 'blackFillsBugFix');
     t.equals('none', svgElement.getElementById('Shape').attributes.fill.value);
+    t.equals('5', svgElement.getElementById('Shape').attributes['stroke-width'].value);
 
     t.end();
 });


### PR DESCRIPTION

### Resolves
Partially resolves https://github.com/LLK/scratch-gui/issues/4109

### Proposed Changes
When early returning, don't forget to set the passed down stroke width and fill

### Reason for Changes
Not setting them was causing fill to be black incorrectly

### Test Coverage
Test adding the sprites affected by black fills in this bug to develop:
https://github.com/LLK/scratch-gui/issues/4109
