### PR TITLE
Import text with newlines. By default, tspans dont show up without an…

### DIFF
--- a/src/svg-renderer.js
+++ b/src/svg-renderer.js
@@ -141,6 +141,7 @@ class SvgRenderer {
             // Set text-before-edge alignment:
             // Scratch renders all text like this.
             textElement.setAttribute('alignment-baseline', 'text-before-edge');
+            textElement.setAttribute('xml:space', 'preserve');
             // If there's no font size provided, provide one.
             if (!textElement.getAttribute('font-size')) {
                 textElement.setAttribute('font-size', '18');
@@ -198,8 +199,9 @@ class SvgRenderer {
                 for (const line of lines) {
                     const tspanNode = SvgElement.create('tspan');
                     tspanNode.setAttribute('x', '0');
+                    tspanNode.setAttribute('style', 'white-space: pre');
                     tspanNode.setAttribute('dy', `${spacing}em`);
-                    tspanNode.textContent = line;
+                    tspanNode.textContent = line ? line : ' ';
                     textElement.appendChild(tspanNode);
                 }
             }


### PR DESCRIPTION
…y content, so insert spaces to allow them to show up on stage.

### Resolves

With https://github.com/LLK/paper.js/pull/25, fixes https://github.com/LLK/scratch-render/issues/292
### Proposed Changes
When converting text to tspans, add a space to empty tspans. In the SVG spec, tspans with no content are ignored, even though they are contributing a dy

### Reason for Changes
Fix importing projects with blank lines in text fields

### Test Coverage
Tested projects 
272026414
203349676
56534898
