### PR TITLE
Don't add stroke widths to image elements

### DIFF
--- a/src/transform-applier.js
+++ b/src/transform-applier.js
@@ -288,7 +288,7 @@ const _transformPath = function (pathString, transform) {
     return result;
 };
 
-const GRAPHICS_ELEMENTS = ['circle', 'ellipse', 'image', 'line', 'path', 'polygon', 'polyline', 'rect', 'text', 'use'];
+const GRAPHICS_ELEMENTS = ['circle', 'ellipse', 'line', 'path', 'polygon', 'polyline', 'rect', 'text', 'use'];
 const CONTAINER_ELEMENTS = ['a', 'defs', 'g', 'marker', 'glyph', 'missing-glyph', 'pattern', 'svg', 'switch', 'symbol'];
 const _isContainerElement = function (element) {
     return element.tagName && CONTAINER_ELEMENTS.includes(element.tagName.toLowerCase());
@@ -582,7 +582,7 @@ const transformStrokeWidths = function (svgTag, windowRef, bboxForTesting) {
             element.setAttribute('fill', fill);
         } else if (_isGraphicsElement(element)) {
             // Push stroke width and fill down to leaves
-            if (strokeWidth && !element.attributes['stroke-width']) {
+            if (strokeWidth && strokeWidth !== 1 && !element.attributes['stroke-width']) {
                 element.setAttribute('stroke-width', strokeWidth);
             }
             if (fill && !element.attributes.fill) {


### PR DESCRIPTION
### Proposed Changes

- Remove 'image' from the list of display elements to fix a bounding box issue when importing svgs from Scratch 2.0.
- Do not apply stroke-width to elements that don't have it when the calculated stroke width is the default value.

Thanks @paulkaplan and @fsih for proposing and talking through the fix.

### Reason for Changes

Resolves an issue with the following project where the costume for the "Stages" sprite is 1px bigger in both width and height, so when the sprite is sent beyond the stage's right edge, it gets positioned half a coordinate away (x: 465.5) from it's position in Scratch 2.0 (x: 465).

https://scratch.mit.edu/projects/269148884/

### Test Coverage

Tested manually with https://scratch.mit.edu/projects/269148884/ and this minimal repro project:
https://scratch.mit.edu/projects/275314781/
