### PR TITLE
Take ceiling of viewbox bounds to prevent clipping (plus add basic test playground)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,9 +4,11 @@
 # NPM
 /node_modules
 npm-*
+/package-lock.json
 
 # Build
 dist/*
+/playground
 
 # Editors
 /#*

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "build": "npm run clean && webpack --progress --colors --bail",
     "clean": "rimraf ./dist",
+    "start": "webpack-dev-server",
     "test": "npm run test:lint && npm run test:unit",
     "test:lint": "eslint . --ext .js",
     "test:unit": "tap ./test/*.js",
@@ -30,6 +31,7 @@
     "babel-eslint": "^8.1.2",
     "babel-loader": "7.1.5",
     "babel-preset-env": "1.6.1",
+    "copy-webpack-plugin": "^4.5.1",
     "eslint": "^4.14.0",
     "eslint-config-scratch": "^5.0.0",
     "eslint-plugin-import": "^2.12.0",
@@ -41,6 +43,7 @@
     "tap": "^11.0.1",
     "webpack": "^4.8.0",
     "webpack-cli": "^3.1.0",
+    "webpack-dev-server": "^3.1.4",
     "xmldom": "^0.1.27"
   }
 }

--- a/src/playground/index.html
+++ b/src/playground/index.html
@@ -1,0 +1,55 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Scratch SVG rendering playground</title>
+</head>
+<body>
+    <p>
+        <input type="file" id="svg-file-upload", accept="image/svg+xml">
+    </p>
+    <p>
+        <label for="render-scale">Scale:</label>
+        <input type="range" id="render-scale" value="1" min="0.5" max="2" step="0.1">
+    </p>
+    <p>
+        <input type="button" id="trigger-render" value="Render">
+    </p>
+
+    <canvas id="render-canvas"></canvas>
+
+    <script src="scratch-svg-renderer.js"></script>
+    <script>
+        const renderCanvas = document.getElementById("render-canvas");
+        const fileChooser = document.getElementById("svg-file-upload");
+        const scaleSlider = document.getElementById("render-scale");
+        const renderButton = document.getElementById("trigger-render");
+
+        const renderer = new ScratchSVGRenderer.SVGRenderer(renderCanvas);
+
+        function renderSVGString(str) {
+            renderer.fromString(str);
+            renderer._draw(parseFloat(scaleSlider.value));
+        }
+
+        function readFileAsText(file) {
+            return new Promise((res, rej) => {
+                const reader = new FileReader();
+  
+                reader.onload = function(event) {
+                    res(reader.result);
+                }
+
+                reader.onerror = console.log;
+
+                reader.readAsText(file);
+            })
+            
+        }
+
+        renderButton.addEventListener("click", (event => {
+            readFileAsText(fileChooser.files[0]).then(renderSVGString).catch(console.error);
+        }));
+    </script>
+</body>
+</html>

--- a/src/playground/index.html
+++ b/src/playground/index.html
@@ -3,6 +3,18 @@
 <head>
     <meta charset="UTF-8">
     <title>Scratch SVG rendering playground</title>
+    <style>
+        .result {
+            /*border:1px solid lightgray*/
+        }
+        #reference {
+            display:inline-block;
+            font-size:0;
+        }
+        .column {
+            display:inline-block;
+        }
+    </style>
 </head>
 <body>
     <p>
@@ -10,26 +22,53 @@
     </p>
     <p>
         <label for="render-scale">Scale:</label>
-        <input type="range" id="render-scale" value="1" min="0.5" max="2" step="0.1">
+        <input type="range" style="width:50%;" id="render-scale" value="1" min="0.5" max="3" step="any">
+        <label for="render-scale" id="scale-display"></label>
     </p>
     <p>
         <input type="button" id="trigger-render" value="Render">
     </p>
 
-    <canvas id="render-canvas"></canvas>
+    <div class="columns">
+        <div class="column">
+            <div>Rendered Result</div>
+            <canvas id="render-canvas" class="result"></canvas>
+       </div>
+       <div class="column">
+            <div>Reference</div>
+            <span id="reference"></span>
+       </div>
+     </div>
+    
 
     <script src="scratch-svg-renderer.js"></script>
     <script>
         const renderCanvas = document.getElementById("render-canvas");
+        const referenceImage = document.getElementById("reference");
         const fileChooser = document.getElementById("svg-file-upload");
         const scaleSlider = document.getElementById("render-scale");
+        const scaleDisplay = document.getElementById("scale-display");
         const renderButton = document.getElementById("trigger-render");
 
         const renderer = new ScratchSVGRenderer.SVGRenderer(renderCanvas);
 
+        let loadedSVGString = "";
+
+        if (fileChooser.value) {
+            loadSVGString();
+        }
+
         function renderSVGString(str) {
             renderer.fromString(str);
             renderer._draw(parseFloat(scaleSlider.value));
+        }
+
+        function updateReferenceImage() {
+            referenceImage.innerHTML = loadedSVGString;
+            scalePercent = (parseFloat(scaleSlider.value) * 100) + "%"
+            referenceSVG = referenceImage.children[0];
+            referenceSVG.style.width = referenceSVG.style.height = scalePercent;
+            referenceSVG.classList.add("result");
         }
 
         function readFileAsText(file) {
@@ -47,8 +86,29 @@
             
         }
 
+        function loadSVGString() {
+            readFileAsText(fileChooser.files[0]).then(str => {
+                loadedSVGString = str;
+            })
+        }
+
+        function renderLoadedString() {
+            renderSVGString(loadedSVGString);
+            updateReferenceImage();
+        }
+
+        function scaleSliderChanged() {
+            renderLoadedString();
+            scaleDisplay.innerText = scaleSlider.value;
+        }
+
+        fileChooser.addEventListener("change", loadSVGString);
+
+        scaleSlider.addEventListener("change", scaleSliderChanged);
+        scaleSlider.addEventListener("input", scaleSliderChanged);
+
         renderButton.addEventListener("click", (event => {
-            readFileAsText(fileChooser.files[0]).then(renderSVGString).catch(console.error);
+            renderLoadedString();
         }));
     </script>
 </body>

--- a/src/playground/index.html
+++ b/src/playground/index.html
@@ -5,7 +5,7 @@
     <title>Scratch SVG rendering playground</title>
     <style>
         .result {
-            /*border:1px solid lightgray*/
+            background-color:gray;
         }
         #reference {
             display:inline-block;

--- a/src/svg-renderer.js
+++ b/src/svg-renderer.js
@@ -393,6 +393,7 @@ class SvgRenderer {
         const scaledWidth  = this._measurements.width  * ratio;
         const scaledHeight = this._measurements.height * ratio;
 
+        // Round render bounds to even integers to prevent non-integer rotation centers
         this._renderBounds = {
             width: Math.ceil(scaledWidth * 0.5) * 2,
             height: Math.ceil(scaledHeight * 0.5) * 2,

--- a/src/svg-renderer.js
+++ b/src/svg-renderer.js
@@ -389,9 +389,13 @@ class SvgRenderer {
 
         const ratio = this.getDrawRatio() * (Number.isFinite(scale) ? scale : 1);
         const bbox = this._measurements;
+        
+        const scaledWidth  = this._measurements.width  * ratio;
+        const scaledHeight = this._measurements.height * ratio;
+
         this._renderBounds = {
-            width: Math.ceil(this._measurements.width * ratio),
-            height: Math.ceil(this._measurements.height * ratio),
+            width: Math.ceil(scaledWidth * 0.5) * 2,
+            height: Math.ceil(scaledHeight * 0.5) * 2,
             x: this._measurements.x,
             y: this._measurements.y
         };
@@ -399,18 +403,8 @@ class SvgRenderer {
         this._canvas.width = this._renderBounds.width;
         this._canvas.height = this._renderBounds.height;
         this._context.clearRect(0, 0, this._canvas.width, this._canvas.height);
-
-        // To make up for the fact that we're rounding the canvas bounds to the highest int,
-        // offset the drawing to re-center it.
-        // Not done because in some browsers (curse you, Firefox), drawing an SVG at non-integer coords is blurry
-        /* this._context.drawImage(
-            this._cachedImage,
-            0,
-            0,
-            this._measurements.width * ratio,
-            this._measurements.height * ratio); */
         
-        this._context.drawImage(this._cachedImage, 0, 0, this._renderBounds.width, this._renderBounds.height);
+        this._context.drawImage(this._cachedImage, 0, 0, scaledWidth,scaledHeight);
         // Set the CSS style of the canvas to the actual measurements.
         this._canvas.style.width = bbox.width;
         this._canvas.style.height = bbox.height;

--- a/src/svg-renderer.js
+++ b/src/svg-renderer.js
@@ -394,7 +394,7 @@ class SvgRenderer {
             height: Math.ceil(this._measurements.height * ratio),
             x: this._measurements.x,
             y: this._measurements.y
-        }
+        };
 
         this._canvas.width = this._renderBounds.width;
         this._canvas.height = this._renderBounds.height;

--- a/src/svg-renderer.js
+++ b/src/svg-renderer.js
@@ -399,14 +399,18 @@ class SvgRenderer {
         this._canvas.width = this._renderBounds.width;
         this._canvas.height = this._renderBounds.height;
         this._context.clearRect(0, 0, this._canvas.width, this._canvas.height);
+
         // To make up for the fact that we're rounding the canvas bounds to the highest int,
         // offset the drawing to re-center it.
-        this._context.drawImage(
+        // Not done because in some browsers (curse you, Firefox), drawing an SVG at non-integer coords is blurry
+        /* this._context.drawImage(
             this._cachedImage,
-            (this._renderBounds.width - (this._measurements.width * ratio)) * 0.5,
-            (this._renderBounds.height - (this._measurements.height * ratio)) * 0.5,
+            0,
+            0,
             this._measurements.width * ratio,
-            this._measurements.height * ratio);
+            this._measurements.height * ratio); */
+        
+        this._context.drawImage(this._cachedImage, 0, 0, this._renderBounds.width, this._renderBounds.height);
         // Set the CSS style of the canvas to the actual measurements.
         this._canvas.style.width = bbox.width;
         this._canvas.style.height = bbox.height;

--- a/src/svg-renderer.js
+++ b/src/svg-renderer.js
@@ -390,7 +390,7 @@ class SvgRenderer {
         const ratio = this.getDrawRatio() * (Number.isFinite(scale) ? scale : 1);
         const bbox = this._measurements;
         
-        const scaledWidth  = this._measurements.width  * ratio;
+        const scaledWidth = this._measurements.width * ratio;
         const scaledHeight = this._measurements.height * ratio;
 
         // Round render bounds to even integers to prevent non-integer rotation centers
@@ -405,7 +405,7 @@ class SvgRenderer {
         this._canvas.height = this._renderBounds.height;
         this._context.clearRect(0, 0, this._canvas.width, this._canvas.height);
         
-        this._context.drawImage(this._cachedImage, 0, 0, scaledWidth,scaledHeight);
+        this._context.drawImage(this._cachedImage, 0, 0, scaledWidth, scaledHeight);
         // Set the CSS style of the canvas to the actual measurements.
         this._canvas.style.width = bbox.width;
         this._canvas.style.height = bbox.height;

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,8 +1,17 @@
+const CopyWebpackPlugin = require('copy-webpack-plugin');
 const defaultsDeep = require('lodash.defaultsdeep');
 const path = require('path');
 
 const base = {
     mode: process.env.NODE_ENV === 'production' ? 'production' : 'development',
+    devServer: {
+        contentBase: false,
+        host: '0.0.0.0',
+        port: process.env.PORT || 8971,
+        watchOptions: {
+            poll: true
+        }
+    },
     devtool: 'cheap-module-source-map',
     entry: {
         'scratch-svg-renderer': './src/index.js'
@@ -19,10 +28,30 @@ const base = {
                 presets: [['env', {targets: {}}]]
             }
         }]
-    }
+    },
+    plugins: []
 };
 
-module.exports =
+module.exports = [
+    defaultsDeep({}, base, {
+        target: 'web',
+        entry: {
+            'scratch-svg-renderer': './src/index.js'
+        },
+        output: {
+            library: 'ScratchSVGRenderer',
+            libraryTarget: 'umd',
+            path: path.resolve('playground'),
+            filename: '[name].js'
+        },
+        plugins: base.plugins.concat([
+            new CopyWebpackPlugin([
+                {
+                    from: 'src/playground'
+                }
+            ])
+        ])
+    }),
     defaultsDeep({}, base, {
         output: {
             library: 'ScratchSVGRenderer',
@@ -40,4 +69,5 @@ module.exports =
         optimization: {
             minimize: process.env.NODE_ENV === 'production'
         }
-    });
+    })
+];


### PR DESCRIPTION
### Resolves

https://github.com/LLK/scratch-render/issues/233

### Proposed Changes

This change attempts to prevent rendered SVGs from clipping by rounding up the values of the viewbox's bounds.

It also adds a new getter to the renderer, renderBounds, which returns the bounds of the canvas the SVG is rendered onto.

Finally, it also adds a basic testing "playground" which I created as part of figuring out this issue.

### Reason for Changes

Clipping is bad, playgrounds are fun, it's 5 AM.
