### PR TITLE
Make font inlining a string operation instead of DOM

### DIFF
--- a/src/svg-renderer.js
+++ b/src/svg-renderer.js
@@ -327,13 +327,11 @@ class SvgRenderer {
      * @returns {string} String representing current SVG data.
      */
     toString (shouldInjectFonts) {
-        let svgDom = this._svgDom;
-        if (shouldInjectFonts) {
-            svgDom = this._svgDom.cloneNode(true /* deep */);
-            inlineSvgFonts(svgDom.documentElement);
-        }
         const serializer = new XMLSerializer();
-        const string = serializer.serializeToString(svgDom);
+        let string = serializer.serializeToString(this._svgDom);
+        if (shouldInjectFonts) {
+            string = inlineSvgFonts(string);
+        }
         return string;
     }
 


### PR DESCRIPTION
This makes loading vector costumes quite a bit faster, since it removes the need to clone the SVG dom and insert large nodes into it, which is a very slow operation. Replace with a simple string manipulation equivalent. On my machine this makes the `toString` operation take about 15-25ms less time.
