### PR TITLE
Preserve zero width and height

### DIFF
--- a/src/svg-renderer.js
+++ b/src/svg-renderer.js
@@ -307,7 +307,14 @@ class SvgRenderer {
         // Enlarge the bbox from the largest found stroke width
         // This may have false-positives, but at least the bbox will always
         // contain the full graphic including strokes.
-        const halfStrokeWidth = this._findLargestStrokeWidth(this._svgTag) / 2;
+        // If the width or height is zero however, don't enlarge since
+        // they won't have a stroke width that needs to be enlarged.
+        let halfStrokeWidth;
+        if (bbox.width === 0 || bbox.height === 0) {
+            halfStrokeWidth = 0;
+        } else {
+            halfStrokeWidth = this._findLargestStrokeWidth(this._svgTag) / 2;
+        }
         const width = bbox.width + (halfStrokeWidth * 2);
         const height = bbox.height + (halfStrokeWidth * 2);
         const x = bbox.x - halfStrokeWidth;


### PR DESCRIPTION
### Resolves

Fixes https://github.com/LLK/scratch-gui/issues/4233

### Proposed Changes

Prevent scaling an SVG with zero height or width.

### Reason for Changes

Currently projects without a costume have their width and height increased from 0x0 to 1x1. This breaks projects where users delete the costume to create an empty SVG and then use the pen tool to try to draw on the stage.   [We have logic to correctly set `rotationCenter` for empty skins with an expected size of 0x0,](https://github.com/LLK/scratch-render/blob/develop/src/Skin.js#L114-L118) , but because the size is 1x1, we're not using that logic. This means Scratch uses the incorrect center of the costume and doesn't allow the pen tool to draw on the full width and height of the stage.

Example project: https://scratch.mit.edu/projects/276971295
When the green flag is clicked, a blue dot should appear in the top left corner of the stage. 
