### PR TITLE
Add a playground page for `scratch-svg-renderer`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ npm-*
 
 # Build
 dist/*
+/playground
 
 # Editors
 /#*

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "build": "npm run clean && webpack --progress --colors --bail",
     "clean": "rimraf ./dist",
+    "start": "webpack-dev-server",
     "test": "npm run test:lint && npm run test:unit",
     "test:lint": "eslint . --ext .js",
     "test:unit": "tap ./test/*.js",
@@ -30,6 +31,7 @@
     "babel-eslint": "^8.1.2",
     "babel-loader": "7.1.5",
     "babel-preset-env": "1.6.1",
+    "copy-webpack-plugin": "^4.5.1",
     "eslint": "^4.14.0",
     "eslint-config-scratch": "^5.0.0",
     "eslint-plugin-import": "^2.12.0",
@@ -41,6 +43,7 @@
     "tap": "^11.0.1",
     "webpack": "^4.8.0",
     "webpack-cli": "^3.1.0",
+    "webpack-dev-server": "^3.1.4",
     "xmldom": "^0.1.27"
   }
 }

--- a/src/playground/index.html
+++ b/src/playground/index.html
@@ -1,0 +1,55 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Scratch SVG rendering playground</title>
+</head>
+<body>
+    <p>
+        <input type="file" id="svg-file-upload", accept="image/svg+xml">
+    </p>
+    <p>
+        <label for="render-scale">Scale:</label>
+        <input type="range" id="render-scale" value="1" min="0.5" max="2" step="0.1">
+    </p>
+    <p>
+        <input type="button" id="trigger-render" value="Render">
+    </p>
+
+    <canvas id="render-canvas"></canvas>
+
+    <script src="scratch-svg-renderer.js"></script>
+    <script>
+        const renderCanvas = document.getElementById("render-canvas");
+        const fileChooser = document.getElementById("svg-file-upload");
+        const scaleSlider = document.getElementById("render-scale");
+        const renderButton = document.getElementById("trigger-render");
+
+        const renderer = new ScratchSVGRenderer.SVGRenderer(renderCanvas);
+
+        function renderSVGString(str) {
+            renderer.fromString(str);
+            renderer._draw(parseFloat(scaleSlider.value));
+        }
+
+        function readFileAsText(file) {
+            return new Promise((res, rej) => {
+                const reader = new FileReader();
+  
+                reader.onload = function(event) {
+                    res(reader.result);
+                }
+
+                reader.onerror = console.log;
+
+                reader.readAsText(file);
+            })
+            
+        }
+
+        renderButton.addEventListener("click", (event => {
+            readFileAsText(fileChooser.files[0]).then(renderSVGString).catch(console.error);
+        }));
+    </script>
+</body>
+</html>

--- a/src/playground/index.html
+++ b/src/playground/index.html
@@ -3,6 +3,18 @@
 <head>
     <meta charset="UTF-8">
     <title>Scratch SVG rendering playground</title>
+    <style>
+        .result {
+            /*border:1px solid lightgray*/
+        }
+        #reference {
+            display:inline-block;
+            font-size:0;
+        }
+        .column {
+            display:inline-block;
+        }
+    </style>
 </head>
 <body>
     <p>
@@ -10,26 +22,53 @@
     </p>
     <p>
         <label for="render-scale">Scale:</label>
-        <input type="range" id="render-scale" value="1" min="0.5" max="2" step="0.1">
+        <input type="range" style="width:50%;" id="render-scale" value="1" min="0.5" max="3" step="any">
+        <label for="render-scale" id="scale-display"></label>
     </p>
     <p>
         <input type="button" id="trigger-render" value="Render">
     </p>
 
-    <canvas id="render-canvas"></canvas>
+    <div class="columns">
+        <div class="column">
+            <div>Rendered Result</div>
+            <canvas id="render-canvas" class="result"></canvas>
+       </div>
+       <div class="column">
+            <div>Reference</div>
+            <span id="reference"></span>
+       </div>
+     </div>
+    
 
     <script src="scratch-svg-renderer.js"></script>
     <script>
         const renderCanvas = document.getElementById("render-canvas");
+        const referenceImage = document.getElementById("reference");
         const fileChooser = document.getElementById("svg-file-upload");
         const scaleSlider = document.getElementById("render-scale");
+        const scaleDisplay = document.getElementById("scale-display");
         const renderButton = document.getElementById("trigger-render");
 
         const renderer = new ScratchSVGRenderer.SVGRenderer(renderCanvas);
 
+        let loadedSVGString = "";
+
+        if (fileChooser.value) {
+            loadSVGString();
+        }
+
         function renderSVGString(str) {
             renderer.fromString(str);
             renderer._draw(parseFloat(scaleSlider.value));
+        }
+
+        function updateReferenceImage() {
+            referenceImage.innerHTML = loadedSVGString;
+            scalePercent = (parseFloat(scaleSlider.value) * 100) + "%"
+            referenceSVG = referenceImage.children[0];
+            referenceSVG.style.width = referenceSVG.style.height = scalePercent;
+            referenceSVG.classList.add("result");
         }
 
         function readFileAsText(file) {
@@ -47,8 +86,29 @@
             
         }
 
+        function loadSVGString() {
+            readFileAsText(fileChooser.files[0]).then(str => {
+                loadedSVGString = str;
+            })
+        }
+
+        function renderLoadedString() {
+            renderSVGString(loadedSVGString);
+            updateReferenceImage();
+        }
+
+        function scaleSliderChanged() {
+            renderLoadedString();
+            scaleDisplay.innerText = scaleSlider.value;
+        }
+
+        fileChooser.addEventListener("change", loadSVGString);
+
+        scaleSlider.addEventListener("change", scaleSliderChanged);
+        scaleSlider.addEventListener("input", scaleSliderChanged);
+
         renderButton.addEventListener("click", (event => {
-            readFileAsText(fileChooser.files[0]).then(renderSVGString).catch(console.error);
+            renderLoadedString();
         }));
     </script>
 </body>

--- a/src/playground/index.html
+++ b/src/playground/index.html
@@ -39,7 +39,6 @@
             <span id="reference"></span>
        </div>
      </div>
-    
 
     <script src="scratch-svg-renderer.js"></script>
     <script>
@@ -74,7 +73,7 @@
         function readFileAsText(file) {
             return new Promise((res, rej) => {
                 const reader = new FileReader();
-  
+
                 reader.onload = function(event) {
                     res(reader.result);
                 }
@@ -83,7 +82,6 @@
 
                 reader.readAsText(file);
             })
-            
         }
 
         function loadSVGString() {

--- a/src/playground/index.html
+++ b/src/playground/index.html
@@ -5,7 +5,7 @@
     <title>Scratch SVG rendering playground</title>
     <style>
         .result {
-            /*border:1px solid lightgray*/
+            background-color:gray;
         }
         #reference {
             display:inline-block;

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -36,6 +36,7 @@ module.exports = [
             library: 'ScratchSVGRenderer',
             libraryTarget: 'umd',
             path: path.resolve('playground'),
+            publicPath: '/',
             filename: '[name].js'
         },
         plugins: base.plugins.concat([

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,8 +1,14 @@
+const CopyWebpackPlugin = require('copy-webpack-plugin');
 const defaultsDeep = require('lodash.defaultsdeep');
 const path = require('path');
 
 const base = {
     mode: process.env.NODE_ENV === 'production' ? 'production' : 'development',
+    devServer: {
+        contentBase: false,
+        host: '0.0.0.0',
+        port: process.env.PORT || 8576
+    },
     devtool: 'cheap-module-source-map',
     entry: {
         'scratch-svg-renderer': './src/index.js'
@@ -19,10 +25,27 @@ const base = {
                 presets: [['env', {targets: {}}]]
             }
         }]
-    }
+    },
+    plugins: []
 };
 
-module.exports =
+module.exports = [
+    defaultsDeep({}, base, {
+        target: 'web',
+        output: {
+            library: 'ScratchSVGRenderer',
+            libraryTarget: 'umd',
+            path: path.resolve('playground'),
+            filename: '[name].js'
+        },
+        plugins: base.plugins.concat([
+            new CopyWebpackPlugin([
+                {
+                    from: 'src/playground'
+                }
+            ])
+        ])
+    }),
     defaultsDeep({}, base, {
         output: {
             library: 'ScratchSVGRenderer',
@@ -40,4 +63,5 @@ module.exports =
         optimization: {
             minimize: process.env.NODE_ENV === 'production'
         }
-    });
+    })
+];


### PR DESCRIPTION
This work was mainly done by @adroitwhiz -- I just separated it out from #71 and made a new PR for it. Thanks, @adroitwhiz!

### Resolves

While this doesn't by itself resolve any issues it should help us more quickly resolve both quality and correctness issues in the future.

### Proposed Changes

This change adds a playground at `http://localhost:8576/playground/` to inspect the results of `scratch-svg-renderer` compared to the browser's default rendering of an SVG.

This is what the playground looks like:
![image](https://user-images.githubusercontent.com/7019101/51636892-2e1af580-1f0f-11e9-8937-3026217fb073.png)

### Reason for Changes

This makes it easier to inspect the output of `scratch-svg-renderer` in isolation, and in particular it might help determine whether a particular problem is in `scratch-svg-renderer` or `scratch-renderer`.
