### PR TITLE
Share one element for svg measuring and one canvas for drawing (if possible)

### DIFF
--- a/src/svg-renderer.js
+++ b/src/svg-renderer.js
@@ -19,6 +19,8 @@ class SvgRenderer {
         this._context = this._canvas.getContext('2d');
         this._measurements = {x: 0, y: 0, width: 0, height: 0};
         this._cachedImage = null;
+        this._svgDom = null;
+        this._svgTag = null;
     }
 
     /**


### PR DESCRIPTION
### Resolves

Decrease memory usage and improve loading performance a little.

### Proposed Changes

- Code maintenance: Declare all members in the constructor
- Use one span element for measuring svgs
- Use one canvas for drawing (if possible)

### Reason for Changes

- Use one span element for measuring svgs
  Creating elements costs costs time, time collecting their garbage, and uses memory. One span node isn't much compared to all the other svg elements created and trashed by this package. But every little bit helps.
- Use one canvas for drawing (if possible)
  In the optimal case using SVGRenderer, it's canvas is used during the callback. If so, we can share one canvas with all the renderers and resize and draw to it since this is all synchronous. If the canvas is accessed outside of the callback we can create and possibly draw to the new canvas.

  This doesn't account for the canvas being stored during the callback and used later. But I feel like the renderer doesn't guarantee that you can do that.

  Anyways reducing the number of canvases is a great memory and performance save.

### Builds

https://mzgoddard.github.io/scratch-gui/perf/20190206-one-element/production/#169401431

### Benchmark Data

Pending ...

#### Memory Data

project | platform |  | develop | one-element
------- | -------- | ---------- | ------- | -----------
169401431 | chrome | after load | 1.1GB | 1.0GB
169401431 | chrome | after idle | 893MB | 833MB
169401431 | chrome gpu | after load | 926MB | 872MB
169401431 | chrome gpu | after idle | 672MB | 617MB
169401431 | firefox | after load | 2,016.57 MB | 1,821.40 MB
169401431 | firefox | after idle | 1,704.40 MB | 1,554.11 MB

Chrome data was collected with its Task Manager window.
Firefox data was collected with its `about:memory` page.