### PR TITLE
Measure a cloned svg node

### DIFF
--- a/src/svg-renderer.js
+++ b/src/svg-renderer.js
@@ -307,31 +307,25 @@ class SvgRenderer {
      * a natural and performant way.
      */
     _transformMeasurements () {
-        // Save `svgText` for later re-parsing.
-        const svgText = this.toString();
-
         // Append the SVG dom to the document.
         // This allows us to use `getBBox` on the page,
         // which returns the full bounding-box of all drawn SVG
         // elements, similar to how Scratch 2.0 did measurement.
         const svgSpot = document.createElement('span');
+        // Clone the svg tag. This tag becomes unusable/undrawable in browsers
+        // once it's appended to the page, perhaps for security reasons?
+        const tempTag = this._svgTag.cloneNode(/* deep */ true);
         let bbox;
         try {
+            svgSpot.appendChild(tempTag);
             document.body.appendChild(svgSpot);
-            svgSpot.appendChild(this._svgTag);
             // Take the bounding box.
-            bbox = this._svgTag.getBBox();
+            bbox = tempTag.getBBox();
         } finally {
             // Always destroy the element, even if, for example, getBBox throws.
             document.body.removeChild(svgSpot);
+            svgSpot.removeChild(tempTag);
         }
-
-        // Re-parse the SVG from `svgText`. The above DOM becomes
-        // unusable/undrawable in browsers once it's appended to the page,
-        // perhaps for security reasons?
-        const parser = new DOMParser();
-        this._svgDom = parser.parseFromString(svgText, 'text/xml');
-        this._svgTag = this._svgDom.documentElement;
 
         // Enlarge the bbox from the largest found stroke width
         // This may have false-positives, but at least the bbox will always


### PR DESCRIPTION
### Resolves

Load projects quickly

### Proposed Changes

- Measure a cloned svg element

### Reason for Changes

We need a extra svg element to measure or replace the measured element. Measuring a cloned element we can skip serializing the svg and later reparsing it.

I separated out this PR since I'm not sure if there are edge cases I am not thinking about. I feel like this may have already been looked into and I couldn't find a recorded reason why we are not using this.

### Benchmark Data

Pending ...
