### PR TITLE
Strip script tags from SVGs

### DIFF
--- a/src/fixup-svg-string.js
+++ b/src/fixup-svg-string.js
@@ -23,5 +23,8 @@ module.exports = function (svgString) {
     // Note: [\s\S] matches everything including newlines, which .* does not
     svgString = svgString.replace(/<metadata>[\s\S]*<\/metadata>/, '');
 
+    // Strip script tags and javascript executing
+    svgString = svgString.replace(/<script[\s\S]*>[\s\S]*<\/script>/, '');
+
     return svgString;
 };

--- a/test/fixtures/script.svg
+++ b/test/fixtures/script.svg
@@ -1,0 +1,8 @@
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN"
+  "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg">
+  <circle cx="250" cy="250" r="50" fill="red" />
+  <script type="text/javascript"><![CDATA[
+      alert('from the svg!')
+  ]]></script>
+</svg>

--- a/test/fixup-svg-string.js
+++ b/test/fixup-svg-string.js
@@ -27,3 +27,12 @@ test('fixupSvgString should make parsing fixtures not throw', t => {
     });
     t.end();
 });
+
+test('fixupSvgString should prevent script tags', t => {
+    const filePath = path.resolve(__dirname, './fixtures/script.svg');
+    const svgString = fs.readFileSync(filePath)
+        .toString();
+    const fixed = fixupSvgString(svgString);
+    t.equal(fixed.indexOf('script'), -1);
+    t.end();
+});


### PR DESCRIPTION
Strip script tags from SVGs to fix parsing issues.