### PR TITLE
Don't multiply SVG size by device pixel ratio

### DIFF
--- a/src/svg-renderer.js
+++ b/src/svg-renderer.js
@@ -33,7 +33,7 @@ class SvgRenderer {
      * This will be parsed and transformed, and finally drawn.
      * When drawing is finished, the `onFinish` callback is called.
      * @param {string} svgString String of SVG data to draw in quirks-mode.
-     * @param {number} [scale] - Optionally, also scale the image by this factor (multiplied by `getDrawRatio()`).
+     * @param {number} [scale] - Optionally, also scale the image by this factor.
      * @param {Function} [onFinish] Optional callback for when drawing finished.
      */
     fromString (svgString, scale, onFinish) {
@@ -366,22 +366,8 @@ class SvgRenderer {
     }
 
     /**
-     * Get the drawing ratio, adjusted for HiDPI screens.
-     * @return {number} Scale ratio to draw to canvases with.
-     */
-    getDrawRatio () {
-        const devicePixelRatio = window.devicePixelRatio || 1;
-        const backingStoreRatio = this._context.webkitBackingStorePixelRatio ||
-            this._context.mozBackingStorePixelRatio ||
-            this._context.msBackingStorePixelRatio ||
-            this._context.oBackingStorePixelRatio ||
-            this._context.backingStorePixelRatio || 1;
-        return devicePixelRatio / backingStoreRatio;
-    }
-
-    /**
-     * Draw the SVG to a canvas. The canvas will automatically be scaled by the value returned by `getDrawRatio`.
-     * @param {number} [scale] - Optionally, also scale the image by this factor (multiplied by `getDrawRatio()`).
+     * Draw the SVG to a canvas.
+     * @param {number} [scale] - Optionally, also scale the image by this factor.
      * @param {Function} [onFinish] - An optional callback to call when the draw operation is complete.
      */
     _draw (scale, onFinish) {
@@ -401,13 +387,13 @@ class SvgRenderer {
 
     /**
      * Draw to the canvas from a loaded image element.
-     * @param {number} [scale] - Optionally, also scale the image by this factor (multiplied by `getDrawRatio()`).
+     * @param {number} [scale] - Optionally, also scale the image by this factor.
      * @param {Function} [onFinish] - An optional callback to call when the draw operation is complete.
      **/
     _drawFromImage (scale, onFinish) {
         if (!this._cachedImage) return;
 
-        const ratio = this.getDrawRatio() * (Number.isFinite(scale) ? scale : 1);
+        const ratio = Number.isFinite(scale) ? scale : 1;
         const bbox = this._measurements;
         this._canvas.width = bbox.width * ratio;
         this._canvas.height = bbox.height * ratio;


### PR DESCRIPTION
### Proposed Changes

This changes SvgRenderer so that, when told to draw an SVG at a certain scale, it doesn't multiply the scale by the device pixel ratio.

### Reason for Changes

The WebGLRenderer already handles all the device pixel ratio stuff [EDIT: [here](https://github.com/LLK/scratch-render/blob/cc5fea803ee921234628a425b5f0b3bae81bfbc2/src/RenderWebGL.js#L1604)], and passes the SvgRenderer the proper scale for the device. By enlarging the SVGs here as well, the SvgRenderer makes them too high-resolution. If on a device with pixel ratio 2, for instance, rendered SVGs will be 4 times as large in each dimension instead of 2, and on a device with pixel ratio 3, they will be ***9*** times as large instead of 3.

This causes jaggies from downscaling, reduces graphics performance, and wastes VRAM.