### PR TITLE
Set stroke-linejoin and stroke-linecap to "round" for gradient strokes in 2.0 SVGs

### DIFF
--- a/src/svg-renderer.js
+++ b/src/svg-renderer.js
@@ -102,6 +102,8 @@ class SvgRenderer {
             this._transformText();
             // Transform measurements.
             this._transformMeasurements();
+            // Fix stroke roundedness.
+            this._setGradientStrokeRoundedness();
         } else if (!this._svgTag.getAttribute('viewBox')) {
             // Renderer expects a view box.
             this._transformMeasurements();
@@ -242,13 +244,13 @@ class SvgRenderer {
     }
 
     /**
-     * @param {string} tagName svg tag to search for
+     * @param {string} [tagName] svg tag to search for (or collect all elements if not given)
      * @return {Array} a list of elements with the given tagname in _svgTag
      */
     _collectElements (tagName) {
         const elts = [];
         const collectElements = domElement => {
-            if (domElement.localName === tagName) {
+            if ((domElement.localName === tagName || typeof tagName === 'undefined') && domElement.getAttribute) {
                 elts.push(domElement);
             }
             for (let i = 0; i < domElement.childNodes.length; i++) {
@@ -281,7 +283,7 @@ class SvgRenderer {
     _transformImages () {
         const imageElements = this._collectElements('image');
 
-        // For each image element, set image rendering to pixelated"
+        // For each image element, set image rendering to pixelated
         const pixelatedImages = 'image-rendering: optimizespeed; image-rendering: pixelated;';
         for (const elt of imageElements) {
             if (elt.getAttribute('style')) {
@@ -322,6 +324,23 @@ class SvgRenderer {
         };
         collectStrokeWidths(rootNode);
         return largestStrokeWidth;
+    }
+
+    /**
+     * Find all instances of a URL-referenced `stroke` in the svg. In 2.0, all gradient strokes
+     * have a round `stroke-linejoin` and `stroke-linecap`... for some reason.
+     */
+    _setGradientStrokeRoundedness () {
+        const elements = this._collectElements();
+
+        for (const elt of elements) {
+            if (!elt.style) continue;
+            const stroke = elt.style.stroke || elt.getAttribute('stroke');
+            if (stroke && stroke.match(/^url\(#.*\)$/)) {
+                elt.style['stroke-linejoin'] = 'round';
+                elt.style['stroke-linecap'] = 'round';
+            }
+        }
     }
 
     /**


### PR DESCRIPTION
### Resolves

Resolves the rest of https://github.com/LLK/scratch-render/issues/194
Resolves https://github.com/LLK/scratch-paint/issues/394

### Proposed Changes

This PR adds another function to SvgRenderer which rounds all strokes with a gradient color. This function is only called for 2.0 ("version 2") SVGs. It also changes `SvgRenderer._collectElements` to allow the caller to optionally collect _all_ elements, which I used in the stroke-rounding function.

### Reason for Changes

In Scratch 2.0, for some inexplicable reason, all strokes with a gradient color have rounded joins and caps:
![Peek 2019-04-26 16-49](https://user-images.githubusercontent.com/25993062/56835847-5df5d400-6843-11e9-9cae-d96eab161f15.gif)

This is relied upon in things like the text bubble from project [#186282308](https://llk.github.io/scratch-gui/develop/#186282308):

Current | This PR | Scratch 2.0
-|-|-
![image](https://user-images.githubusercontent.com/25993062/56836011-db214900-6843-11e9-820c-3e1f30c7ebf6.png) | ![image](https://user-images.githubusercontent.com/25993062/56836019-df4d6680-6843-11e9-9a98-6cf781010645.png) | ![image](https://user-images.githubusercontent.com/25993062/56836023-e2485700-6843-11e9-8a31-f61e343c4fd4.png)

