### PR TITLE
Properly handle Scratch 2.0's <image> behavior... but at what cost?

### DIFF
--- a/src/svg-renderer.js
+++ b/src/svg-renderer.js
@@ -260,9 +260,6 @@ class SvgRenderer {
             } else {
                 elt.setAttribute('style', pixelatedImages);
             }
-
-            elt.removeAttribute('x');
-            elt.removeAttribute('y');
         }
     }
 


### PR DESCRIPTION
### Resolves

Resolves #58 (at least for PNGs)

### Proposed Changes

This PR adds a new step to the Scratch 2.0 compatibility mode path that strips the "x" and "y" attributes from `<image>`s, and sets their "width" and "height" to their actual resolution.

Currently, in order to keep `SvgRenderer.fromString()` synchronous, this step only operates on PNG images, reading their width and height directly from their binary data*.

A much more robust solution would be to create an `<img>` element for each SVG `<image>`, and read the width and height from there. However, this only works if you read the dimensions after the `<img>` has loaded, which you need an event callback to do. This would make `SvgRenderer.fromString()` an asynchronous function, which has implications for the rest of the Scratch codebase.

### Reason for Changes

Scratch 2.0 ignores `<image>`s' "x", "y", "width", and "height", only recognizing the "transform" attribute.

*it's not an ugly hack if it's well-commented, amirite?
