### PR TITLE
Throw an error if inlineSvgFonts is called on a non-string

### DIFF
--- a/src/font-inliner.js
+++ b/src/font-inliner.js
@@ -18,6 +18,12 @@ const {FONTS} = require('scratch-render-fonts');
  * @return {string} The svg with any needed fonts inlined
  */
 const inlineSvgFonts = function (svgString) {
+    // Make it clear that this function only operates on strings.
+    // If we don't explicitly throw this here, the function silently fails.
+    if (typeof svgString !== 'string') {
+        throw new Error('SVG to be inlined is not a string');
+    }
+
     // Collect fonts that need injection.
     const fontsNeeded = new Set();
     const fontRegex = /font-family="([^"]*)"/g;


### PR DESCRIPTION
### Proposed Changes

This adds a check to `inlineSvgFonts` that ensures it is passed a string and not, say, an `SVGElement` or other input. If it's passed an invalid type, it will now throw an error.

### Reason for Changes

`inlineSvgFonts` could easily be accidentally passed an `SVGElement` (as happened in https://github.com/LLK/scratch-paint/issues/841). Before this change, it would fail silently and return the input without changing anything.
