### PR TITLE
Add renderedSize getter (for real this time)

### DIFF
--- a/src/svg-renderer.js
+++ b/src/svg-renderer.js
@@ -18,6 +18,7 @@ class SvgRenderer {
         this._canvas = canvas || document.createElement('canvas');
         this._context = this._canvas.getContext('2d');
         this._measurements = {x: 0, y: 0, width: 0, height: 0};
+        this._renderedSize = {width: 0, height: 0};
         this._cachedImage = null;
     }
 
@@ -56,6 +57,13 @@ class SvgRenderer {
      */
     get size () {
         return [this._measurements.width, this._measurements.height];
+    }
+
+    /**
+     * @return {Array<number>} the resolution of the canvas this SVG was rendered onto, in pixels.
+     */
+    get renderedSize () {
+        return [this._renderedSize.width, this._renderedSize.height];
     }
 
     /**
@@ -411,6 +419,10 @@ class SvgRenderer {
         const bbox = this._measurements;
         this._canvas.width = bbox.width * ratio;
         this._canvas.height = bbox.height * ratio;
+
+        this._renderedSize.width = this._canvas.width;
+        this._renderedSize.height = this._canvas.height;
+
         this._context.clearRect(0, 0, this._canvas.width, this._canvas.height);
         this._context.scale(ratio, ratio);
         this._context.drawImage(this._cachedImage, 0, 0);

--- a/src/svg-renderer.js
+++ b/src/svg-renderer.js
@@ -18,7 +18,6 @@ class SvgRenderer {
         this._canvas = canvas || document.createElement('canvas');
         this._context = this._canvas.getContext('2d');
         this._measurements = {x: 0, y: 0, width: 0, height: 0};
-        this._renderedSize = {width: 0, height: 0};
         this._cachedImage = null;
     }
 
@@ -63,7 +62,7 @@ class SvgRenderer {
      * @return {Array<number>} the resolution of the canvas this SVG was rendered onto, in pixels.
      */
     get renderedSize () {
-        return [this._renderedSize.width, this._renderedSize.height];
+        return [this._canvas.width, this._canvas.height];
     }
 
     /**
@@ -419,9 +418,6 @@ class SvgRenderer {
         const bbox = this._measurements;
         this._canvas.width = bbox.width * ratio;
         this._canvas.height = bbox.height * ratio;
-
-        this._renderedSize.width = this._canvas.width;
-        this._renderedSize.height = this._canvas.height;
 
         this._context.clearRect(0, 0, this._canvas.width, this._canvas.height);
         this._context.scale(ratio, ratio);


### PR DESCRIPTION
Unfortunately, GitHub considers this a different branch from the one I pushed to in #81, so I have to create a whole new PR for the third time.

### Proposed Changes

Proposed Changes

This change adds a new getter to the renderer, `renderedSize`, which returns the pixel dimensions of the canvas the SVG is rendered onto.

### Reason for Changes

Knowing the texture size is necessary for properly fixing `useNearest` for `SVGSkin`s over in the renderer-- we can only use nearest-neighbor interpolation if there's less than a pixel's difference between the texture size and the screen-space size.
