### PR TITLE
Fix SVGs with namespace declarations binding to reserved namespace name

### DIFF
--- a/src/fixup-svg-string.js
+++ b/src/fixup-svg-string.js
@@ -29,6 +29,17 @@ module.exports = function (svgString) {
         );
     }
 
+    // Some SVGs from Inkscape attempt to bind a prefix to a reserved namespace name.
+    // This will cause SVG parsing to fail, so replace these with a dummy namespace name.
+    if (svgString.match(/xmlns:.*="http:\/\/www.w3.org\/XML\/1998\/namespace"/) !== null) {
+        svgString = svgString.replace(
+            // capture the entire attribute
+            /(xmlns:.*)="http:\/\/www.w3.org\/XML\/1998\/namespace"/g,
+            // use the captured attribute name; replace only the URL
+            ($0, $1) => `${$1}="http://dummy.namespace"`
+        );
+    }
+
     // The <metadata> element is not needed for rendering and sometimes contains
     // unparseable garbage from Illustrator :(
     // Note: [\s\S] matches everything including newlines, which .* does not

--- a/test/fixtures/reserved-namespace.svg
+++ b/test/fixtures/reserved-namespace.svg
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg version="1.1" viewBox="0 0 68 68" xmlns="http://www.w3.org/2000/svg">
+    <rect aaa:space="preserve" x="2" y="2" width="64" height="64" fill="white" stroke="black" stroke-width="4" xmlns:aaa="http://www.w3.org/XML/1998/namespace"/>
+</svg>

--- a/test/fixup-svg-string.js
+++ b/test/fixup-svg-string.js
@@ -28,6 +28,20 @@ test('fixupSvgString should make parsing fixtures not throw', t => {
     t.end();
 });
 
+test('fixupSvgString should correct namespace declarations bound to reserved namespace names', t => {
+    const filePath = path.resolve(__dirname, './fixtures/reserved-namespace.svg');
+    const svgString = fs.readFileSync(filePath)
+        .toString();
+    const fixed = fixupSvgString(svgString);
+
+    // Make sure undefineds aren't being written into the file
+    t.equal(fixed.indexOf('undefined'), -1);
+    t.notThrow(() => {
+        domParser.parseFromString(fixed, 'text/xml');
+    });
+    t.end();
+});
+
 test('fixupSvgString should prevent script tags', t => {
     const filePath = path.resolve(__dirname, './fixtures/script.svg');
     const svgString = fs.readFileSync(filePath)


### PR DESCRIPTION
### Resolves

Resolves #95

### Proposed Changes

This adds another SVG string fixup step which checks for namespace declarations bound to the namespace name `http://www.w3.org/XML/1998/namespace`, and instead binds them to a dummy namespace.

### Reason for Changes

`http://www.w3.org/XML/1998/namespace` is a reserved namespace name, and any declarations binding to it will fail and cause the parser to error out. Some SVGs created in Inkscape do this and are not loaded properly.

Note that web browsers will not render these SVGs either, so they will not appear properly in the sprite pane and will crash the paint editor:
![image](https://user-images.githubusercontent.com/25993062/60989842-fcf37d80-a314-11e9-9373-1b93499863da.png)

### Test Coverage

A test SVG with an invalid namespace declaration has been added.
