### PR TITLE
Don't "fix" xmlns:xml namespace bindings

### DIFF
--- a/src/fixup-svg-string.js
+++ b/src/fixup-svg-string.js
@@ -31,10 +31,12 @@ module.exports = function (svgString) {
 
     // Some SVGs from Inkscape attempt to bind a prefix to a reserved namespace name.
     // This will cause SVG parsing to fail, so replace these with a dummy namespace name.
-    if (svgString.match(/xmlns:.*="http:\/\/www.w3.org\/XML\/1998\/namespace"/) !== null) {
+    // This namespace name is only valid for "xml", and if we bind "xmlns:xml" to the dummy namespace,
+    // parsing will fail yet again, so exclude "xmlns:xml" declarations.
+    if (svgString.match(/xmlns:(?!xml=)[^ ]+="http:\/\/www.w3.org\/XML\/1998\/namespace"/) !== null) {
         svgString = svgString.replace(
             // capture the entire attribute
-            /(xmlns:.*)="http:\/\/www.w3.org\/XML\/1998\/namespace"/g,
+            /(xmlns:(?!xml=)[^ ]+)="http:\/\/www.w3.org\/XML\/1998\/namespace"/g,
             // use the captured attribute name; replace only the URL
             ($0, $1) => `${$1}="http://dummy.namespace"`
         );

--- a/test/fixtures/reserved-namespace.svg
+++ b/test/fixtures/reserved-namespace.svg
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg version="1.1" viewBox="0 0 68 68" xmlns="http://www.w3.org/2000/svg">
+<svg version="1.1" viewBox="0 0 68 68" xmlns="http://www.w3.org/2000/svg" xmlns:xml="http://www.w3.org/XML/1998/namespace">
     <rect aaa:space="preserve" x="2" y="2" width="64" height="64" fill="white" stroke="black" stroke-width="4" xmlns:aaa="http://www.w3.org/XML/1998/namespace"/>
 </svg>


### PR DESCRIPTION
### Resolves

Resolves https://github.com/LLK/scratch-gui/issues/5105

### Proposed Changes

This PR changes the "fix prefixes bound to reserved namespace names" to not attempt to "fix" the "xml" prefix.

### Reason for Changes

The "xml" prefix is the only prefix that can be bound to the namespace name "http://www.w3.org/XML/1998/namespace". If it is changed to be bound to any other namespace, as the previous code did, parsing would fail.

### Test Coverage

The test SVG used for checking reserved namespaces now includes an "xmlns:xml" binding.
