### PR TITLE
Use baseVal.numberOfItems instead of length

### DIFF
--- a/src/svg-renderer.js
+++ b/src/svg-renderer.js
@@ -183,7 +183,7 @@ class SvgRenderer {
                 ty = -4 * fontSize / 22;
             }
 
-            if (textElement.transform.baseVal.length === 0) {
+            if (textElement.transform.baseVal.numberOfItems === 0) {
                 const transform = this._svgTag.createSVGTransform();
                 textElement.transform.baseVal.appendItem(transform);
             }


### PR DESCRIPTION
Use numberOfItems instead of length, which is not supported on Edge and Safari
https://developer.mozilla.org/en-US/docs/Web/API/SVGTransformList

Fixes https://github.com/LLK/scratch-gui/issues/3381
Fixes https://github.com/LLK/scratch-gui/issues/2245
Fixes one of the issues in https://github.com/LLK/scratch-svg-renderer/issues/95