### PR TITLE
Add new `draw` and `loadSVG` methods to the `SvgRenderer`

### DIFF
--- a/src/svg-renderer.js
+++ b/src/svg-renderer.js
@@ -19,6 +19,7 @@ class SvgRenderer {
         this._context = this._canvas.getContext('2d');
         this._measurements = {x: 0, y: 0, width: 0, height: 0};
         this._cachedImage = null;
+        this.loaded = false;
     }
 
     /**
@@ -26,13 +27,6 @@ class SvgRenderer {
      */
     get canvas () {
         return this._canvas;
-    }
-
-    /**
-     * @returns {boolean} True if this renderer's set SVG has been loaded and can be rendered, false if not.
-     */
-    get loaded () {
-        return this._cachedImage !== null;
     }
 
     /**
@@ -139,14 +133,16 @@ class SvgRenderer {
      * @param {Function} [onFinish] - An optional callback to call when the <img> has loaded.
      */
     _createSVGImage (onFinish) {
-        const img = new Image();
-        this._cachedImage = null;
+        if (this._cachedImage === null) this._cachedImage = new Image();
+        const img = this._cachedImage;
+
         img.onload = () => {
-            this._cachedImage = img;
+            this.loaded = true;
             if (onFinish) onFinish();
         };
         const svgText = this.toString(true /* shouldInjectFonts */);
         img.src = `data:image/svg+xml;utf8,${encodeURIComponent(svgText)}`;
+        this.loaded = false;
     }
 
     /**
@@ -406,7 +402,7 @@ class SvgRenderer {
      * @param {number} [scale] - Optionally, also scale the image by this factor.
      */
     draw (scale) {
-        if (this._cachedImage === null) throw new Error('SVG image has not finished loading');
+        if (!this.loaded) throw new Error('SVG image has not finished loading');
         this._drawFromImage(scale);
     }
 


### PR DESCRIPTION
### Resolves

A step towards resolving https://github.com/LLK/scratch-render/issues/518

### Proposed Changes

This PR adds two public methods and one private method to `SvgRenderer`:

- `loadSVG`, which takes in an SVG string, loads it with `fromString`, creates an `<img>` that can be rendered to a canvas, then calls the passed callback
- `draw` (not `_draw`), which synchronously draws a previously loaded SVG to the `SvgRenderer.canvas`
- `_createSVGImage`, which handles creation of the `<img>` itself

It also:
- Adds the `loaded` ~~getter~~ property, which returns whether or not the `<img>` has finished loading and can be rendered.
- Deprecates `fromString` and `_draw`. I checked `scratch-gui`, `scratch-paint`, and `scratch-vm`, and none of them use these methods--it's only `scratch-render` that uses them, and with https://github.com/LLK/scratch-render/pull/527 merged, it will stop using them.

### Reason for Changes

Currently, the `SvgRenderer`'s methods conflate:

- The **asynchronous** operation of loading a *new* SVG as an `<img>` element
- The **synchronous** operation of drawing an *already loaded* SVG to a `<canvas>` at an arbitrary scale

This can result in unpredictable behavior. For instance, the `_draw` method executes asynchronously the first time it is called after a new SVG has been loaded, as it has not yet created an `<img>` from the SVG. However, subsequent calls will be synchronous, as the `<img>` has been created and can be synchronously drawn to a `<canvas>`.

These changes make the synchronous/asynchronous split explicit with new methods that are either always synchronous or always asynchronous.