### PR TITLE
Fix SVG font inlining in Edge

### DIFF
--- a/src/font-inliner.js
+++ b/src/font-inliner.js
@@ -3,6 +3,9 @@
  */
 const {FONTS} = require('scratch-render-fonts');
 
+// This must be initialized via the RegExp constructor because Edge won't parse this as a regex literal.
+const svgTagRegex = new RegExp('<svg[^>]*>');
+
 /**
  * Given SVG data, inline the fonts. This allows them to be rendered correctly when set
  * as the source of an HTMLImageElement. Here is a note from tmickel:
@@ -40,7 +43,7 @@ const inlineSvgFonts = function (svgString) {
             }
         }
         str += '</style></defs>';
-        svgString = svgString.replace(/<svg[^>]*>/, `$&${str}`);
+        svgString = svgString.replace(svgTagRegex, `$&${str}`);
         return svgString;
     }
     return svgString;


### PR DESCRIPTION
### Resolves

Resolves #110 

### Proposed Changes

This PR changes the regex literal in `inlineSvgFonts`, which matches the SVG opening tag, into a `RegExp` constructor.

### Reason for Changes

Edge's regex parser seems to fail on certain regex literals. Unfortunately I can't figure this out in any more detail because *all of the Microsoft Developer forum pages, where people report Edge bugs, are 404ing*.

While I have confirmed manually that SVG fonts are now properly inlined, Edge still won't render them. Still, this is a step forward. So far I know that if I append the `<img>` of the SVG to the document, the fonts won't load in Edge. On the other hand, if I open the SVG file itself, they will.