### PR TITLE
Leave empty metadata and script tags rather than stripping them 

### DIFF
--- a/src/fixup-svg-string.js
+++ b/src/fixup-svg-string.js
@@ -43,12 +43,12 @@ module.exports = function (svgString) {
     }
 
     // The <metadata> element is not needed for rendering and sometimes contains
-    // unparseable garbage from Illustrator :(
+    // unparseable garbage from Illustrator :( Empty out the contents.
     // Note: [\s\S] matches everything including newlines, which .* does not
-    svgString = svgString.replace(/<metadata>[\s\S]*<\/metadata>/, '');
+    svgString = svgString.replace(/<metadata>[\s\S]*<\/metadata>/, '<metadata></metadata>');
 
-    // Strip script tags and javascript executing
-    svgString = svgString.replace(/<script[\s\S]*>[\s\S]*<\/script>/, '');
+    // Empty script tags and javascript executing
+    svgString = svgString.replace(/<script[\s\S]*>[\s\S]*<\/script>/, '<script></script>');
 
     return svgString;
 };

--- a/test/fixtures/metadata-body.svg
+++ b/test/fixtures/metadata-body.svg
@@ -1,0 +1,6 @@
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN"
+  "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg">
+  <circle cx="250" cy="250" r="50" fill="red" />
+  <metadata>stuff inside</metadata>
+</svg>

--- a/test/fixtures/metadata-onload.svg
+++ b/test/fixtures/metadata-onload.svg
@@ -1,0 +1,7 @@
+<svg
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   version="1.1">
+     <image xlink:href="data:image/svg+xml;base64,PHN2ZyBpZD0iTGF5ZXJfMSIgZGF0YS1uYW1lPSJMYXllciAxIiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAxNi42MyAxNy41Ij48ZGVmcz48c3R5bGU+LmNscy0xLC5jbHMtMntmaWxsOiM0Y2JmNTY7c3Ryb2tlOiM0NTk5M2Q7c3Ryb2tlLWxpbmVjYXA6cm91bmQ7c3Ryb2tlLWxpbmVqb2luOnJvdW5kO30uY2xzLTJ7c3Ryb2tlLXdpZHRoOjEuNXB4O308L3N0eWxlPjwvZGVmcz48dGl0bGU+aWNvbi0tZ3JlZW4tZmxhZzwvdGl0bGU+PHBhdGggY2xhc3M9ImNscy0xIiBkPSJNLjc1LDJBNi40NCw2LjQ0LDAsMCwxLDguNDQsMmgwYTYuNDQsNi40NCwwLDAsMCw3LjY5LDBWMTIuNGE2LjQ0LDYuNDQsMCwwLDEtNy42OSwwaDBhNi40NCw2LjQ0LDAsMCwwLTcuNjksMCIvPjxsaW5lIGNsYXNzPSJjbHMtMiIgeDE9IjAuNzUiIHkxPSIxNi43NSIgeDI9IjAuNzUiIHkyPSIwLjc1Ii8+PC9zdmc+"
+         onlo<metadata></metadata>ad="alert('from the svg')"> </image>
+</svg>

--- a/test/fixtures/onload-script.svg
+++ b/test/fixtures/onload-script.svg
@@ -1,0 +1,7 @@
+<svg
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   version="1.1">
+   <image xlink:href="data:image/svg+xml;base64,PHN2ZyBpZD0iTGF5ZXJfMSIgZGF0YS1uYW1lPSJMYXllciAxIiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAxNi42MyAxNy41Ij48ZGVmcz48c3R5bGU+LmNscy0xLC5jbHMtMntmaWxsOiM0Y2JmNTY7c3Ryb2tlOiM0NTk5M2Q7c3Ryb2tlLWxpbmVjYXA6cm91bmQ7c3Ryb2tlLWxpbmVqb2luOnJvdW5kO30uY2xzLTJ7c3Ryb2tlLXdpZHRoOjEuNXB4O308L3N0eWxlPjwvZGVmcz48dGl0bGU+aWNvbi0tZ3JlZW4tZmxhZzwvdGl0bGU+PHBhdGggY2xhc3M9ImNscy0xIiBkPSJNLjc1LDJBNi40NCw2LjQ0LDAsMCwxLDguNDQsMmgwYTYuNDQsNi40NCwwLDAsMCw3LjY5LDBWMTIuNGE2LjQ0LDYuNDQsMCwwLDEtNy42OSwwaDBhNi40NCw2LjQ0LDAsMCwwLTcuNjksMCIvPjxsaW5lIGNsYXNzPSJjbHMtMiIgeDE9IjAuNzUiIHkxPSIxNi43NSIgeDI9IjAuNzUiIHkyPSIwLjc1Ii8+PC9zdmc+"
+   onlo<script></script>ad="alert('from the svg')"> </image>
+</svg>

--- a/test/fixup-svg-string.js
+++ b/test/fixup-svg-string.js
@@ -42,12 +42,47 @@ test('fixupSvgString should correct namespace declarations bound to reserved nam
     t.end();
 });
 
-test('fixupSvgString should prevent script tags', t => {
+test('fixupSvgString should empty script tags', t => {
     const filePath = path.resolve(__dirname, './fixtures/script.svg');
     const svgString = fs.readFileSync(filePath)
         .toString();
     const fixed = fixupSvgString(svgString);
-    t.equal(fixed.indexOf('script'), -1);
+    // Script tag should remain but have no contents.
+    t.equals(fixed.indexOf('<script></script>'), 207);
+    // The contents of the script tag (e.g. the alert) are no longer there.
+    t.equals(fixed.indexOf('stuff inside'), -1);
+    t.end();
+});
+
+test('fixupSvgString should empty script tags in onload', t => {
+    const filePath = path.resolve(__dirname, './fixtures/onload-script.svg');
+    const svgString = fs.readFileSync(filePath)
+        .toString();
+    const fixed = fixupSvgString(svgString);
+    // Script tag should remain but have no contents.
+    t.equals(fixed.indexOf('<script></script>'), 792);
+    t.end();
+});
+
+test('fixupSvgString strips contents of metadata', t => {
+    const filePath = path.resolve(__dirname, './fixtures/metadata-body.svg');
+    const svgString = fs.readFileSync(filePath)
+        .toString();
+    const fixed = fixupSvgString(svgString);
+    // Metadata tag should still exist, it'll just be empty.
+    t.equals(fixed.indexOf('<metadata></metadata>'), 207);
+    // The contents of the metadata tag are gone.
+    t.equals(fixed.indexOf('stuff inside'), -1);
+    t.end();
+});
+
+test('fixupSvgString strips contents of metadata in onload', t => {
+    const filePath = path.resolve(__dirname, './fixtures/metadata-onload.svg');
+    const svgString = fs.readFileSync(filePath)
+        .toString();
+    const fixed = fixupSvgString(svgString);
+    // Metadata tag should still exist, it'll just be empty.
+    t.equals(fixed.indexOf('<metadata></metadata>'), 800);
     t.end();
 });
 


### PR DESCRIPTION
completely.