### PR TITLE
Only fix XML namespace attributes if they're actually attributes

### DIFF
--- a/src/fixup-svg-string.js
+++ b/src/fixup-svg-string.js
@@ -33,12 +33,13 @@ module.exports = function (svgString) {
     // This will cause SVG parsing to fail, so replace these with a dummy namespace name.
     // This namespace name is only valid for "xml", and if we bind "xmlns:xml" to the dummy namespace,
     // parsing will fail yet again, so exclude "xmlns:xml" declarations.
-    if (svgString.match(/xmlns:(?!xml=)[^ ]+="http:\/\/www.w3.org\/XML\/1998\/namespace"/) !== null) {
+    const xmlnsRegex = /(<[^>]+?xmlns:(?!xml=)[^ ]+=)"http:\/\/www.w3.org\/XML\/1998\/namespace"/g;
+    if (svgString.match(xmlnsRegex) !== null) {
         svgString = svgString.replace(
             // capture the entire attribute
-            /(xmlns:(?!xml=)[^ ]+)="http:\/\/www.w3.org\/XML\/1998\/namespace"/g,
+            xmlnsRegex,
             // use the captured attribute name; replace only the URL
-            ($0, $1) => `${$1}="http://dummy.namespace"`
+            ($0, $1) => `${$1}"http://dummy.namespace"`
         );
     }
 

--- a/test/fixup-svg-string.js
+++ b/test/fixup-svg-string.js
@@ -42,6 +42,13 @@ test('fixupSvgString should correct namespace declarations bound to reserved nam
     t.end();
 });
 
+test('fixupSvgString shouldn\'t correct non-attributes', t => {
+    const dontFix = fixupSvgString('<text>xmlns:test="http://www/w3.org/XML/1998/namespace" is not an xmlns attribute</text>');
+
+    t.notEqual(dontFix.indexOf('http://www/w3.org/XML/1998/namespace'), -1);
+    t.end();
+});
+
 test('fixupSvgString should empty script tags', t => {
     const filePath = path.resolve(__dirname, './fixtures/script.svg');
     const svgString = fs.readFileSync(filePath)


### PR DESCRIPTION
### Proposed Changes

This PR changes the fixupSvgString step introduced in #96 to only fix attributes that are actually attributes (aka that actually appear inside of tags).

### Reason for Changes

![image](https://user-images.githubusercontent.com/25993062/71043425-92810d80-20fc-11ea-80e5-f9f30a622698.png)

Regex is hard, okay? :cry: 


### Test Coverage

A new test has been added to ensure that this behavior doesn't occur.
