### PR TITLE
Don't draw if one of the canvas dimensions is 0

### DIFF
--- a/src/svg-renderer.js
+++ b/src/svg-renderer.js
@@ -436,6 +436,7 @@ class SvgRenderer {
         const bbox = this._measurements;
         this._canvas.width = bbox.width * ratio;
         this._canvas.height = bbox.height * ratio;
+        if (this._canvas.width <= 0 || this._canvas.height <= 0) return;
         this._context.clearRect(0, 0, this._canvas.width, this._canvas.height);
         this._context.scale(ratio, ratio);
         this._context.drawImage(this._cachedImage, 0, 0);


### PR DESCRIPTION
### Resolves

Resolves part of https://github.com/LLK/scratch-render/issues/538

### Proposed Changes

This PR changes `SvgRenderer._drawFromImage` to not draw anything if one of its `<canvas>`' dimensions is 0.

### Reason for Changes

This prevents an `IndexSizeError` from being thrown when images with a dimension of 0 are drawn.
