### PR TITLE
Supporting SVG renderer changes for subpixel bounds

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,8 @@ const scale = 1;
 const quirksMode = false;
 function doSomethingWith(canvas) {...};
 
-svgRenderer.loadSVG(svgData, quirksMode, () => {
+svgRenderer.loadString(svgData, quirksMode);
+svgRenderer.createSVGImage(() => {
 	svgRenderer.draw(scale);
 	doSomethingWith(svgRenderer.canvas);
 });

--- a/README.md
+++ b/README.md
@@ -21,8 +21,17 @@ npm install
 ```js
 import SvgRenderer from 'scratch-svg-renderer';
 
-var svgRenderer = new SvgRenderer();
-svgRenderer.fromString(svgData, callback);
+const svgRenderer = new SvgRenderer();
+
+const svgData = "<svg>...</svg>";
+const scale = 1;
+const quirksMode = false;
+function doSomethingWith(canvas) {...};
+
+svgRenderer.loadSVG(svgData, quirksMode, () => {
+	svgRenderer.draw(scale);
+	doSomethingWith(svgRenderer.canvas);
+});
 ```
 
 ## Donate

--- a/src/playground/index.html
+++ b/src/playground/index.html
@@ -88,7 +88,7 @@
         function loadSVGString() {
             readFileAsText(fileChooser.files[0]).then(str => {
                 loadedSVGString = str;
-                renderer.loadSVG(str, false);
+                renderer.loadString(str, false);
             })
         }
 

--- a/src/playground/index.html
+++ b/src/playground/index.html
@@ -58,8 +58,9 @@
         }
 
         function renderSVGString(str) {
-            renderer.fromString(str);
-            renderer._draw(parseFloat(scaleSlider.value));
+            if (renderer.loaded) {
+                renderer.draw(parseFloat(scaleSlider.value));
+            }
         }
 
         function updateReferenceImage() {
@@ -87,6 +88,7 @@
         function loadSVGString() {
             readFileAsText(fileChooser.files[0]).then(str => {
                 loadedSVGString = str;
+                renderer.loadSVG(str, false);
             })
         }
 

--- a/src/svg-renderer.js
+++ b/src/svg-renderer.js
@@ -453,13 +453,8 @@ class SvgRenderer {
         this._canvas.height = bbox.height * ratio;
         if (this._canvas.width <= 0 || this._canvas.height <= 0) return;
         this._context.clearRect(0, 0, this._canvas.width, this._canvas.height);
-        this._context.scale(ratio, ratio);
+        this._context.setTransform(ratio, 0, 0, ratio, 0, 0);
         this._context.drawImage(this._cachedImage, 0, 0);
-        // Reset the canvas transform after drawing.
-        this._context.setTransform(1, 0, 0, 1, 0, 0);
-        // Set the CSS style of the canvas to the actual measurements.
-        this._canvas.style.width = bbox.width;
-        this._canvas.style.height = bbox.height;
     }
 }
 

--- a/src/svg-renderer.js
+++ b/src/svg-renderer.js
@@ -150,7 +150,7 @@ class SvgRenderer {
      * @param {Array<number>} rotationCenter The rotation center of the Skin this SVG is used for.
      * @param {number} minScale The minimum scale at which this SVG should be rendered with proper subpixel positioning.
      */
-    _setSubpixelViewbox (rotationCenter, minScale) {
+    setSubpixelViewbox (rotationCenter, minScale) {
         // The preserveAspectRatio attribute has all sorts of weird effects on the viewBox if enabled.
         this._svgTag.setAttribute('preserveAspectRatio', 'none');
 
@@ -233,7 +233,7 @@ class SvgRenderer {
         this.loadString(svgString, fromVersion2);
 
         if (rotationCenter && minScale) {
-            this._setSubpixelViewbox(rotationCenter, minScale);
+            this.setSubpixelViewbox(rotationCenter, minScale);
         } else {
             this.adjustedRotationCenter[0] = this.measurements.x;
             this.adjustedRotationCenter[1] = this.measurements.y;
@@ -241,14 +241,14 @@ class SvgRenderer {
             this.adjustedSize[1] = this.measurements.height;
         }
 
-        this._createSVGImage(onFinish);
+        this.createSVGImage(onFinish);
     }
 
     /**
      * Creates an <img> element for the currently loaded SVG string, then calls the callback once it's loaded.
      * @param {Function} [onFinish] - An optional callback to call when the <img> has loaded.
      */
-    _createSVGImage (onFinish) {
+    createSVGImage (onFinish) {
         if (this._cachedImage === null) this._cachedImage = new Image();
         const img = this._cachedImage;
 

--- a/src/svg-renderer.js
+++ b/src/svg-renderer.js
@@ -15,10 +15,41 @@ class SvgRenderer {
      * @constructor
      */
     constructor (canvas) {
+        /**
+         * The canvas that this SVG renderer will render to.
+         * @type {HTMLCanvasElement}
+         * @private
+         */
         this._canvas = canvas || document.createElement('canvas');
         this._context = this._canvas.getContext('2d');
+
+        /**
+         * A measured SVG "viewbox"
+         * @typedef {object} SvgRenderer#SvgMeasurements
+         * @property {number} x - The left edge of the SVG viewbox.
+         * @property {number} y - The top edge of the SVG viewbox.
+         * @property {number} width - The width of the SVG viewbox.
+         * @property {number} height - The height of the SVG viewbox.
+         */
+
+        /**
+         * The measurement box of the currently loaded SVG.
+         * @type {SvgRenderer#SvgMeasurements}
+         * @private
+         */
         this._measurements = {x: 0, y: 0, width: 0, height: 0};
+
+        /**
+         * The `<img>` element with the contents of the currently loaded SVG.
+         * @type {HTMLImageElement}
+         * @private
+         */
         this._cachedImage = null;
+
+        /**
+         * True if this renderer's current SVG is loaded and can be rendered to the canvas.
+         * @type {boolean}
+         */
         this.loaded = false;
     }
 

--- a/src/svg-renderer.js
+++ b/src/svg-renderer.js
@@ -30,22 +30,6 @@ class SvgRenderer {
     }
 
     /**
-     * Load an SVG from a string and draw it.
-     * This will be parsed and transformed, and finally drawn.
-     * When drawing is finished, the `onFinish` callback is called.
-     * @param {string} svgString String of SVG data to draw in quirks-mode.
-     * @param {number} [scale] - Optionally, also scale the image by this factor.
-     * @param {Function} [onFinish] Optional callback for when drawing finished.
-     * @deprecated Use the `loadSVG` method and public `draw` method instead.
-     */
-    fromString (svgString, scale, onFinish) {
-        this.loadSVG(svgString, false, () => {
-            this.draw(scale);
-            if (onFinish) onFinish();
-        });
-    }
-
-    /**
      * Load an SVG from a string and measure it.
      * @param {string} svgString String of SVG data to draw in quirks-mode.
      * @return {object} the natural size, in Scratch units, of this SVG.
@@ -423,25 +407,6 @@ class SvgRenderer {
     draw (scale) {
         if (!this.loaded) throw new Error('SVG image has not finished loading');
         this._drawFromImage(scale);
-    }
-
-    /**
-     * Asynchronously draw the (possibly non-loaded) SVG to a canvas.
-     * @param {number} [scale] - Optionally, also scale the image by this factor.
-     * @param {Function} [onFinish] - An optional callback to call when the draw operation is complete.
-     * @deprecated Use the `loadSVG` and public `draw` method instead.
-     */
-    _draw (scale, onFinish) {
-        // Convert the SVG text to an Image, and then draw it to the canvas.
-        if (this._cachedImage === null) {
-            this._createSVGImage(() => {
-                this._drawFromImage(scale);
-                onFinish();
-            });
-        } else {
-            this._drawFromImage(scale);
-            onFinish();
-        }
     }
 
     /**

--- a/src/svg-renderer.js
+++ b/src/svg-renderer.js
@@ -221,30 +221,6 @@ class SvgRenderer {
     }
 
     /**
-     * Load an SVG string, normalize it, and prepare it for (synchronous) rendering.
-     * @param {!string} svgString String of SVG data to draw in quirks-mode.
-     * @param {?boolean} fromVersion2 True if we should perform conversion from version 2 to version 3 svg.
-     * @param {Function} [onFinish] - An optional callback to call when the SVG is loaded and can be rendered.
-     * @param {Array<number>} [rotationCenter] - Optionally, the rotation center of the Skin this SVG is used for,
-     * relative to the top-left corner of the viewbox.
-     * @param {number} [minScale] - Optionally, the minimum scale this SVG will be rendered at.
-     */
-    loadSVG (svgString, fromVersion2, onFinish, rotationCenter, minScale) {
-        this.loadString(svgString, fromVersion2);
-
-        if (rotationCenter && minScale) {
-            this.setSubpixelViewbox(rotationCenter, minScale);
-        } else {
-            this.adjustedRotationCenter[0] = this.measurements.x;
-            this.adjustedRotationCenter[1] = this.measurements.y;
-            this.adjustedSize[0] = this.measurements.width;
-            this.adjustedSize[1] = this.measurements.height;
-        }
-
-        this.createSVGImage(onFinish);
-    }
-
-    /**
      * Creates an <img> element for the currently loaded SVG string, then calls the callback once it's loaded.
      * @param {Function} [onFinish] - An optional callback to call when the <img> has loaded.
      */


### PR DESCRIPTION
### Resolves

Half of resolving https://github.com/LLK/scratch-render/issues/427

### Proposed Changes

- Remove the old, unused `_draw` and `fromString` methods
- Make `measurements` public and add `adjustedRotationCenter`, `adjustedSize`, and `adjustedMeasurements`
- Remove `loadSVG`, make `createSVGImage` public, and add `setSubpixelViewbox`
- Remove `viewOffset`

### Reason for Changes

These changes implement the SVG side of the changes described in https://github.com/LLK/scratch-render/issues/550. They allow for the bounding box and rotation center of a loaded SVG to be adjusted so that it can be rendered at an integer size and integer coordinates.

The supporting API changes give scratch-render more control over what happens when, and were done as necessary to make things function in scratch-render. These more tightly couple scratch-render and this repo, but I'm not sure how else to implement this stuff--any suggestions on reducing coupling are greatly appreciated.

### Test Coverage

Still needs some discussion

### To do
- Remove `adjustedSize` and just grab width/height from `adjustedMeasurements`
- See if any other places in the codebase use `SvgRenderer.size` or if the renderer can grab that from `measurements`