### PR TITLE
Transform gradients in strokes

### DIFF
--- a/src/element-categories.js
+++ b/src/element-categories.js
@@ -1,0 +1,30 @@
+// Elements that can have paint attributes (e.g. fill and stroke)
+// Per the SVG spec, things like fill and stroke apply to shapes and text content elements
+// https://www.w3.org/TR/SVG11/painting.html#FillProperty
+// https://www.w3.org/TR/SVG11/painting.html#StrokeProperty
+const PAINTABLE_ELEMENTS = new Set([
+    // Shape elements (https://www.w3.org/TR/SVG11/intro.html#TermShape)
+    'path', 'rect', 'circle', 'ellipse', 'line', 'polyline', 'polygon',
+    // Text content elements (https://www.w3.org/TR/SVG11/intro.html#TermTextContentElement)
+    // The actual tag names are `altGlyph` and `textPath`, but we're lowercasing the tag name in isContainerElement,
+    // so they should be lowercased here too.
+    'altglyph', 'textpath', 'text', 'tref', 'tspan'
+]);
+
+// "An element which can have graphics elements and other container elements as child elements."
+// https://www.w3.org/TR/SVG11/intro.html#TermContainerElement
+const CONTAINER_ELEMENTS = new Set([
+    'a', 'defs', 'g', 'marker', 'glyph', 'missing-glyph', 'pattern', 'svg', 'switch', 'symbol'
+]);
+
+const isPaintableElement = function (element) {
+    return element.tagName && PAINTABLE_ELEMENTS.has(element.tagName.toLowerCase());
+};
+const isContainerElement = function (element) {
+    return element.tagName && CONTAINER_ELEMENTS.has(element.tagName.toLowerCase());
+};
+
+module.exports = {
+    isPaintableElement,
+    isContainerElement
+};

--- a/src/transform-applier.js
+++ b/src/transform-applier.js
@@ -561,8 +561,8 @@ const transformStrokeWidths = function (svgTag, windowRef, bboxForTesting) {
                 } else {
                     try {
                         doc.body.appendChild(svgSpot);
-                        const svg = SvgElement.set(windowRef.document.createElementNS(SvgElement.svg, 'svg'));
-                        const path = SvgElement.set(windowRef.document.createElementNS(SvgElement.svg, 'path'));
+                        const svg = SvgElement.set(doc.createElementNS(SvgElement.svg, 'svg'));
+                        const path = SvgElement.set(doc.createElementNS(SvgElement.svg, 'path'));
                         path.setAttribute('d', element.attributes.d.value);
                         svg.appendChild(path);
                         svgSpot.appendChild(svg);

--- a/src/transform-applier.js
+++ b/src/transform-applier.js
@@ -372,6 +372,13 @@ const _createGradient = function (gradientId, svgTag, bbox, matrix) {
     const newGradientId = `${gradientId}-${matrixString}`;
     newGradient.setAttribute('id', newGradientId);
 
+    // This gradient already exists and was transformed before. Just reuse the already-transformed one.
+    if (svgTag.getElementById(newGradientId)) {
+        // This is the same code as in the end of the function, but I don't feel like wrapping the next 80 lines
+        // in an `if (!svgTag.getElementById(newGradientId))` block
+        return `url(#${newGradientId})`;
+    }
+
     const scaleToBounds = getValue(newGradient, 'gradientUnits', true) !==
                 'userSpaceOnUse';
     let origin;

--- a/src/transform-applier.js
+++ b/src/transform-applier.js
@@ -1,5 +1,6 @@
 const Matrix = require('transformation-matrix');
 const SvgElement = require('./svg-element');
+const {isPaintableElement, isContainerElement} = require('./element-categories');
 const log = require('./util/log');
 
 /**
@@ -288,14 +289,6 @@ const _transformPath = function (pathString, transform) {
     return result;
 };
 
-const GRAPHICS_ELEMENTS = ['circle', 'ellipse', 'image', 'line', 'path', 'polygon', 'polyline', 'rect', 'text', 'use'];
-const CONTAINER_ELEMENTS = ['a', 'defs', 'g', 'marker', 'glyph', 'missing-glyph', 'pattern', 'svg', 'switch', 'symbol'];
-const _isContainerElement = function (element) {
-    return element.tagName && CONTAINER_ELEMENTS.includes(element.tagName.toLowerCase());
-};
-const _isGraphicsElement = function (element) {
-    return element.tagName && GRAPHICS_ELEMENTS.includes(element.tagName.toLowerCase());
-};
 const _isPathWithTransformAndStroke = function (element, strokeWidth) {
     if (!element.attributes) return false;
     strokeWidth = element.attributes['stroke-width'] ?
@@ -514,7 +507,7 @@ const transformStrokeWidths = function (svgTag, windowRef, bboxForTesting) {
     const inherited = Matrix.identity();
 
     const applyTransforms = (element, matrix, strokeWidth, fill, stroke) => {
-        if (_isContainerElement(element)) {
+        if (isContainerElement(element)) {
             // Push fills and stroke width down to leaves
             if (element.attributes['stroke-width']) {
                 strokeWidth = element.attributes['stroke-width'].value;
@@ -601,7 +594,7 @@ const transformStrokeWidths = function (svgTag, windowRef, bboxForTesting) {
             element.setAttribute('stroke-width', _quadraticMean(matrixScale.x, matrixScale.y) * strokeWidth);
             if (fill) element.setAttribute('fill', fill);
             if (stroke) element.setAttribute('stroke', stroke);
-        } else if (_isGraphicsElement(element)) {
+        } else if (isPaintableElement(element)) {
             // Push stroke width, fill, and stroke down to leaves
             if (strokeWidth && !element.attributes['stroke-width']) {
                 element.setAttribute('stroke-width', strokeWidth);


### PR DESCRIPTION
### Resolves

Resolves #142

### Proposed Changes

This PR extends the gradient-transforming logic in `transformStrokeWidths` to transform gradients not only in fills (as it previously did) but in strokes as well.

### Reason for Changes

Strokes can also have gradients (and https://github.com/LLK/scratch-paint/pull/1004 makes this much more likely). Previously, they weren't being taken into account when transforms were being applied.

### Test Coverage

Tested manually
