### PR TITLE
Fix crash when drawing really small SVGs

### DIFF
--- a/src/svg-renderer.js
+++ b/src/svg-renderer.js
@@ -455,7 +455,15 @@ class SvgRenderer {
         const bbox = this._measurements;
         this._canvas.width = bbox.width * ratio;
         this._canvas.height = bbox.height * ratio;
-        if (this._canvas.width <= 0 || this._canvas.height <= 0) return;
+        // Even if the canvas at the current scale has a nonzero size, the image's dimensions are floored pre-scaling.
+        // e.g. if an image has a width of 0.4 and is being rendered at 3x scale, the canvas will have a width of 1, but
+        // the image's width will be rounded down to 0 on some browsers (Firefox) prior to being drawn at that scale.
+        if (
+            this._canvas.width <= 0 ||
+            this._canvas.height <= 0 ||
+            this._cachedImage.naturalWidth <= 0 ||
+            this._cachedImage.naturalHeight <= 0
+        ) return;
         this._context.clearRect(0, 0, this._canvas.width, this._canvas.height);
         this._context.scale(ratio, ratio);
         this._context.drawImage(this._cachedImage, 0, 0);


### PR DESCRIPTION
### Resolves

Resolves #170

### Proposed Changes

This PR adds another condition to the "zero-size" check in `_drawFromImage` that ensures that the image's dimensions, not just the canvas dimensions, are greater than 0.

### Reason for Changes

See the comment added to the code. Some browsers will round down the dimensions of a really small image to 0 *prior* to drawing them at a certain scale, meaning that even if you scale them up such that they have a nonzero size, they won't draw and will throw an `IndexSizeError`.

### Test Coverage

None, because this only happens on Firefox AFAIK
