### PR TITLE
Export fixupSvgString from module

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,6 @@
 const SVGRenderer = require('./svg-renderer');
 const BitmapAdapter = require('./bitmap-adapter');
+const fixupSvgString = require('./fixup-svg-string');
 const inlineSvgFonts = require('./font-inliner');
 const SvgElement = require('./svg-element');
 const convertFonts = require('./font-converter');
@@ -10,6 +11,7 @@ const convertFonts = require('./font-converter');
 module.exports = {
     BitmapAdapter: BitmapAdapter,
     convertFonts: convertFonts,
+    fixupSvgString: fixupSvgString,
     inlineSvgFonts: inlineSvgFonts,
     SvgElement: SvgElement,
     SVGRenderer: SVGRenderer


### PR DESCRIPTION
### Resolves

Resolves #97
EDIT: also resolves #50

### Proposed Changes

This PR exports the `fixupSvgString` function from this module, allowing it to be used in the paint editor and other repos (I think the GUI may benefit from using it in the sprite selector panel, but I can't remember).

### Reason for Changes

Currently, the paint editor has its own "fixup SVG string" step which has diverged from the `fixupSvgString` function in this repo. This results in certain SVGs being displayed properly in the player, but crashing the paint editor when you try to modify them.

Allowing the paint editor to call `fixupSvgString` from here will ensure that all SVGs renderable here will also be editable in the paint editor without it crashing upon import.
