### PR TITLE
Clean up SVG renderer code

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,8 +21,17 @@ npm install
 ```js
 import SvgRenderer from 'scratch-svg-renderer';
 
-var svgRenderer = new SvgRenderer();
-svgRenderer.fromString(svgData, callback);
+const svgRenderer = new SvgRenderer();
+
+const svgData = "<svg>...</svg>";
+const scale = 1;
+const quirksMode = false; // If true, emulate Scratch 2.0 SVG rendering "quirks"
+function doSomethingWith(canvas) {...};
+
+svgRenderer.loadSVG(svgData, quirksMode, () => {
+	svgRenderer.draw(scale);
+	doSomethingWith(svgRenderer.canvas);
+});
 ```
 
 ## How to run locally as part of scratch-gui

--- a/src/playground/index.html
+++ b/src/playground/index.html
@@ -72,9 +72,10 @@
             loadSVGString();
         }
 
-        function renderSVGString(str) {
-            renderer.fromString(str);
-            renderer._draw(parseFloat(scaleSlider.value), ()=>{});
+        function renderSVGString() {
+            if (renderer.loaded) {
+                renderer.draw(parseFloat(scaleSlider.value));
+            }
             renderedContent.value = renderer.toString(true);
         }
 
@@ -103,11 +104,12 @@
         function loadSVGString() {
             readFileAsText(fileChooser.files[0]).then(str => {
                 loadedSVGString = str;
+                renderer.loadSVG(str, false);
             })
         }
 
         function renderLoadedString() {
-            renderSVGString(loadedSVGString);
+            renderSVGString();
             referenceContent.value = loadedSVGString;
             shouldRenderReference.checked && updateReferenceImage();
         }

--- a/src/svg-renderer.js
+++ b/src/svg-renderer.js
@@ -474,13 +474,8 @@ class SvgRenderer {
             this._cachedImage.naturalHeight <= 0
         ) return;
         this._context.clearRect(0, 0, this._canvas.width, this._canvas.height);
-        this._context.scale(ratio, ratio);
+        this._context.setTransform(ratio, 0, 0, ratio, 0, 0);
         this._context.drawImage(this._cachedImage, 0, 0);
-        // Reset the canvas transform after drawing.
-        this._context.setTransform(1, 0, 0, 1, 0, 0);
-        // Set the CSS style of the canvas to the actual measurements.
-        this._canvas.style.width = bbox.width;
-        this._canvas.style.height = bbox.height;
     }
 }
 

--- a/src/svg-renderer.js
+++ b/src/svg-renderer.js
@@ -31,22 +31,6 @@ class SvgRenderer {
     }
 
     /**
-     * Load an SVG from a string and draw it.
-     * This will be parsed and transformed, and finally drawn.
-     * When drawing is finished, the `onFinish` callback is called.
-     * @param {string} svgString String of SVG data to draw in quirks-mode.
-     * @param {number} [scale] - Optionally, also scale the image by this factor.
-     * @param {Function} [onFinish] Optional callback for when drawing finished.
-     * @deprecated Use the `loadSVG` method and public `draw` method instead.
-     */
-    fromString (svgString, scale, onFinish) {
-        this.loadSVG(svgString, false, () => {
-            this.draw(scale);
-            if (onFinish) onFinish();
-        });
-    }
-
-    /**
      * Load an SVG from a string and measure it.
      * @param {string} svgString String of SVG data to draw in quirks-mode.
      * @return {object} the natural size, in Scratch units, of this SVG.
@@ -436,25 +420,6 @@ class SvgRenderer {
     draw (scale) {
         if (!this.loaded) throw new Error('SVG image has not finished loading');
         this._drawFromImage(scale);
-    }
-
-    /**
-     * Asynchronously draw the (possibly non-loaded) SVG to a canvas.
-     * @param {number} [scale] - Optionally, also scale the image by this factor.
-     * @param {Function} [onFinish] - An optional callback to call when the draw operation is complete.
-     * @deprecated Use the `loadSVG` and public `draw` method instead.
-     */
-    _draw (scale, onFinish) {
-        // Convert the SVG text to an Image, and then draw it to the canvas.
-        if (this._cachedImage === null) {
-            this._createSVGImage(() => {
-                this._drawFromImage(scale);
-                onFinish();
-            });
-        } else {
-            this._drawFromImage(scale);
-            onFinish();
-        }
     }
 
     /**

--- a/src/svg-renderer.js
+++ b/src/svg-renderer.js
@@ -16,10 +16,41 @@ class SvgRenderer {
      * @constructor
      */
     constructor (canvas) {
+        /**
+         * The canvas that this SVG renderer will render to.
+         * @type {HTMLCanvasElement}
+         * @private
+         */
         this._canvas = canvas || document.createElement('canvas');
         this._context = this._canvas.getContext('2d');
+
+        /**
+         * A measured SVG "viewbox"
+         * @typedef {object} SvgRenderer#SvgMeasurements
+         * @property {number} x - The left edge of the SVG viewbox.
+         * @property {number} y - The top edge of the SVG viewbox.
+         * @property {number} width - The width of the SVG viewbox.
+         * @property {number} height - The height of the SVG viewbox.
+         */
+
+        /**
+         * The measurement box of the currently loaded SVG.
+         * @type {SvgRenderer#SvgMeasurements}
+         * @private
+         */
         this._measurements = {x: 0, y: 0, width: 0, height: 0};
+
+        /**
+         * The `<img>` element with the contents of the currently loaded SVG.
+         * @type {?HTMLImageElement}
+         * @private
+         */
         this._cachedImage = null;
+
+        /**
+         * True if this renderer's current SVG is loaded and can be rendered to the canvas.
+         * @type {boolean}
+         */
         this.loaded = false;
     }
 


### PR DESCRIPTION
### Resolves

A step towards #211 and https://github.com/LLK/scratch-render/pull/594

### Proposed Changes

This includes the first 3 commits from #127, with the requested changes made:

* Remove deprecated, now-unused functions from `SvgRenderer`, and update the documentation and playground to match.
* Document `SvgRenderer`'s properties.
* Clean up the scaling code in `SvgRenderer._drawFromImage`.

### Reason for Changes

These changes make it easier to split `SvgRenderer` up into multiple parts, some of which can be moved into the specific repositories which need them, and allow more complex changes like the ones required by https://github.com/LLK/scratch-render/pull/594 to be implemented without touching this repo.

### Test Coverage

All existing tests pass
