### PR TITLE
Clarify BitmapAdapter.resize logic

### DIFF
--- a/src/bitmap-adapter.js
+++ b/src/bitmap-adapter.js
@@ -13,10 +13,19 @@ class BitmapAdapter {
         this._makeCanvas = makeCanvas ? makeCanvas : () => document.createElement('canvas');
     }
 
-    // Returns a canvas with the resized image
+    /**
+     * Return a canvas with the resized version of the given image, done using nearest-neighbor interpolation
+     * @param {CanvasImageSource} image The image to resize
+     * @param {int} newWidth The desired post-resize width of the image
+     * @param {int} newHeight The desired post-resize height of the image
+     * @returns {HTMLCanvasElement} A canvas with the resized image drawn on it.
+     */
     resize (image, newWidth, newHeight) {
-        // Resize in a 2 step process, matching width first, then height, in order
-        // to preserve nearest-neighbor sampling.
+        // We want to always resize using nearest-neighbor interpolation. However, canvas implementations are free to
+        // use linear interpolation (or other "smooth" interpolation methods) when downscaling:
+        // https://bugzilla.mozilla.org/show_bug.cgi?id=1360415
+        // It seems we can get around this by resizing in two steps: first width, then height. This will always result
+        // in nearest-neighbor interpolation, even when downscaling.
         const stretchWidthCanvas = this._makeCanvas();
         stretchWidthCanvas.width = newWidth;
         stretchWidthCanvas.height = image.height;


### PR DESCRIPTION
### Resolves

Resolves #122

### Proposed Changes

This PR adds JSDoc for `BitmapAdapter.resize`, and clarifies the reason why it resizes in two passes. I've confirmed that this explanation is actually true (nearest-neighbor downscaling does not work if scaling is done in a single pass) at least on Firefox.

### Reason for Changes

This should make the codebase clearer to those reading over it.

### Test Coverage

N/A; this is a comment-only change. Testing that nearest-neighbor interpolation is always used when downscaling would be a good idea, but we'd need browser-based testing for that which is a can of worms to open another time.
