### PR TITLE
use Node LTS on CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: node_js
 node_js:
-  - 6
-  - node
+  - lts/*
 env:
   global:
     - NODE_ENV=production
@@ -21,7 +20,6 @@ jobs:
       script:
       - npm run test
     - stage: deploy
-      node_js: 6
       script: npm run build
       before_deploy:
       - >


### PR DESCRIPTION
### Proposed Changes

Adjust our Travis CI settings to use Node LTS, and only Node LTS.

### Reason for Changes

Previously we used Node v6, which has been out of support for nearly two years. Recently, our builds on Travis CI started failing because an indirect dependency has updated to use syntax not supported in Node v6. Targeting `lts/*` means we'll always target an LTS version of Node, so we should stay compatible with current module versions without needing to worry about potential instability in the "current" (not-yet-LTS) versions of Node.

We could explicitly specify some or all LTS versions (currently 10, 12, and 14). Considering this configuration previously specified Node 6, I think it's fair to say we're unlikely to update that list every 6 months; that's what we'd need to keep it fresh. For example: about 6 weeks from now the LTS list will include Node 12 and 14 only, and Node 16 will become LTS about 6 months from now.

Besides, we'll probably migrate to Circle CI soon, which will specify these versions in some other way.

### Test Coverage

See Travis CI build output