### PR TITLE
CE-137: introduce sanitize-svg library

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -2,6 +2,7 @@ const SVGRenderer = require('./svg-renderer');
 const BitmapAdapter = require('./bitmap-adapter');
 const inlineSvgFonts = require('./font-inliner');
 const loadSvgString = require('./load-svg-string');
+const sanitizeSvg = require('./sanitize-svg');
 const serializeSvgToString = require('./serialize-svg-to-string');
 const SvgElement = require('./svg-element');
 const convertFonts = require('./font-converter');
@@ -14,6 +15,7 @@ module.exports = {
     convertFonts: convertFonts,
     inlineSvgFonts: inlineSvgFonts,
     loadSvgString: loadSvgString,
+    sanitizeSvg: sanitizeSvg,
     serializeSvgToString: serializeSvgToString,
     SvgElement: SvgElement,
     SVGRenderer: SVGRenderer

--- a/src/sanitize-svg.js
+++ b/src/sanitize-svg.js
@@ -1,0 +1,7 @@
+const DOMPurify = require('dompurify');
+
+const sanitizeSvg = rawSVGText => DOMPurify.sanitize(rawSVGText, {
+    USE_PROFILES: {svg: true}
+});
+
+module.exports = sanitizeSvg;

--- a/src/sanitize-svg.js
+++ b/src/sanitize-svg.js
@@ -1,7 +1,26 @@
 const DOMPurify = require('dompurify');
+const fixupSvgString = require('./fixup-svg-string');
 
-const sanitizeSvg = rawSVGText => DOMPurify.sanitize(rawSVGText, {
-    USE_PROFILES: {svg: true}
+// Add a hook to post-process a sanitized SVG
+DOMPurify.addHook('afterSanitizeAttributes', node => {
+    // Fix namespaces added by Adobe Illustrator
+    node.setAttribute('xmlns', 'http://www.w3.org/2000/svg');
+    node.setAttribute('xmlns:xlink', 'http://www.w3.org/1999/xlink');
 });
+
+const sanitizeSvg = rawSVGText => {
+    // Clean SVG string and allow the "filter" tag
+    let cleanedSVGText = DOMPurify.sanitize(rawSVGText, {
+        ADD_TAGS: ['filter'],
+        USE_PROFILES: {svg: true, svgFilters: true}
+    });
+    // Remove partial XML comment that is sometimes left in the HTML
+    const badTag = cleanedSVGText.indexOf(']&gt;');
+    cleanedSVGText = cleanedSVGText.substring(badTag < 0 ? 0 : 5, cleanedSVGText.length);
+
+    // also use our custom fixup rules
+    cleanedSVGText = fixupSvgString(cleanedSVGText);
+    return cleanedSVGText;
+};
 
 module.exports = sanitizeSvg;


### PR DESCRIPTION
### Resolves

related to https://github.com/LLK/scratch-svg-renderer/issues/219

### Proposed Changes

Adds function to sanitize an SVG using DOMPurify

### Reason for Changes

Part of ongoing work to close SVG security holes

