### PR TITLE
feat: sanitize css @import rules

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
   "dependencies": {
     "base64-js": "1.2.1",
     "base64-loader": "1.0.0",
+    "css-tree": "1.1.3",
     "dompurify": "2.2.7",
     "fastestsmallesttextencoderdecoder": "^1.0.22",
     "minilog": "3.1.0",

--- a/test/fixtures/css-import.sanitized.svg
+++ b/test/fixtures/css-import.sanitized.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg">
+    <defs>
+        <style type="text/css">.normal{fill:"red"}</style>
+    </defs>
+</svg>

--- a/test/fixtures/css-import.svg
+++ b/test/fixtures/css-import.svg
@@ -1,0 +1,11 @@
+<svg xmlns="http://www.w3.org/2000/svg">
+    <defs>
+        <style type="text/css">
+            @import url('https://scratch.mit.edu/site-api/comments/user/auwhefi');
+            @import "https://scratch.mit.edu/site-api/comments/user/auwhefi";
+            .normal {
+                fill: "red";
+            }
+        </style>
+    </defs>
+</svg>


### PR DESCRIPTION
### Resolves

- [ENA-145](https://scratchfoundation.atlassian.net/browse/ENA-145)

### Proposed Changes

- Parse all `<style>` elements and filter out any `@import` at-rules from the CSS

### Reason for Changes

`@import` is used to import style rules from other stylesheets. A malicious user could include a reference to a url that they own. Then whenever anyone opens this svg file the malicious user can capture, at a minimum, your IP address. We do not want to leak PII.

This code change catches 2 paths:

1. When uploading a costume, `sanitizeSvgText` will strip any `@import`s before uploading to the server.
2. When loading a project with v2 assets or missing a `viewBox` attribute, `loadSvgString` needs to load the SVG to correctly measure the dimensions. The `@imports` will be sanitized in this scenario. Sanitation is not needed during normal costume display because it is rendered as an image and [will not load external resources](https://developer.mozilla.org/en-US/docs/Web/SVG/SVG_as_an_Image). 

### Test Coverage

- Added test fixture containing `@import` at-rules
- [ENA-145](https://scratchfoundation.atlassian.net/browse/ENA-145) contains assets that can be used for manual testing
