### PR TITLE
fix: update svg sanitization to handle more cases of url attacks

### DIFF
--- a/src/sanitize-svg.js
+++ b/src/sanitize-svg.js
@@ -70,12 +70,13 @@ DOMPurify.addHook(
                 ) {
                     let shouldRemove = false;
 
-                    walk(astNode.value, (valueNode) => {
+                    walk(astNode.value, valueNode => {
                         if (
                             valueNode.type === 'Url' ||
                             (valueNode.type === 'Function' && valueNode.name.toLowerCase() === 'url')
                         ) {
-                            const urlValue = (valueNode.value || '').toString().trim().replace(/['"]/g, '');
+                            const urlValue = (valueNode.value || '').toString().trim()
+                                .replace(/['"]/g, '');
 
                             if (!urlValue.startsWith('#')) {
                                 shouldRemove = true;

--- a/src/sanitize-svg.js
+++ b/src/sanitize-svg.js
@@ -27,6 +27,24 @@ DOMPurify.addHook(
                 }
             }
         }
+
+        // Remove url(...) usages where the reference is external
+        if (currentNode && currentNode.attributes) {
+            for (let i = currentNode.attributes.length - 1; i >= 0; i--) {
+                const attr = currentNode.attributes[i];
+                const rawValue = attr.value || '';
+                const value = rawValue.toLowerCase().replace(/\s/g, '');
+        
+                const urlMatch = value.match(/url\((.+?)\)/);
+                if (urlMatch) {
+                    const ref = urlMatch[1].replace(/['"]/g, '');
+                    if (!ref.startsWith('#')) {
+                        currentNode.removeAttribute(attr.name);
+                    }
+                }
+            }
+        }
+    
         return currentNode;
     }
 );
@@ -37,13 +55,41 @@ DOMPurify.addHook(
         if (data.tagName === 'style') {
             const ast = parse(node.textContent);
             let isModified = false;
-            // Remove any @import rules as it could leak HTTP requests
+
             walk(ast, (astNode, item, list) => {
-                if (astNode.type === 'Atrule' && astNode.name === 'import') {
+                // @import rules
+                if (astNode.type === 'Atrule' && astNode.name.toLowerCase() === 'import') {
                     list.remove(item);
                     isModified = true;
                 }
+            
+                // Elements using url(...) for external resources
+                if (
+                    astNode.type === 'Declaration' &&
+                    astNode.value
+                ) {
+                    let shouldRemove = false;
+
+                    walk(astNode.value, (valueNode) => {
+                        if (
+                            valueNode.type === 'Url' ||
+                            (valueNode.type === 'Function' && valueNode.name.toLowerCase() === 'url')
+                        ) {
+                            const urlValue = (valueNode.value || '').toString().trim().replace(/['"]/g, '');
+
+                            if (!urlValue.startsWith('#')) {
+                                shouldRemove = true;
+                            }
+                        }
+                    });
+            
+                    if (shouldRemove) {
+                        list.remove(item);
+                        isModified = true;
+                    }
+                }
             });
+
             if (isModified) {
                 node.textContent = generate(ast);
             }

--- a/test/fixtures/css-links.sanitized.svg
+++ b/test/fixtures/css-links.sanitized.svg
@@ -1,0 +1,17 @@
+<svg xmlns="http://www.w3.org/2000/svg">
+    <defs>
+        <path></path>
+    </defs>
+
+    <circle></circle>
+    <circle></circle>
+
+    <rect></rect>
+    <rect></rect>
+
+    <style>.url{}</style>
+    <rect class="url"></rect>
+
+    <style>@font-face{font-family:'Test Font'}text{font-family:'Test Font'}</style>
+    <text>Use developer tools to observe several requests to example.com</text>
+</svg>

--- a/test/fixtures/css-links.svg
+++ b/test/fixtures/css-links.svg
@@ -1,0 +1,34 @@
+<svg xmlns="http://www.w3.org/2000/svg">
+    <defs>
+        <path mask="url(https://example.com/using-path-mask-attribute)"></path>
+    </defs>
+
+    <circle fill="url(https://example.com/using-circle-fill-attribute)" />
+    <circle style="fill: url(https://example.com/using-circle-fill-inline-style)" />
+
+    <rect stroke="url(https://example.com/using-rect-stroke-attribute)" />
+    <rect style="stroke: url(https://example.com/using-rect-fill-inline-style)" />
+
+    <style>
+        .url {
+            fill: url(https://example.com/using-fill-stylesheet);
+            stroke: url(https://example.com/using-stroke-stylesheet);
+            background-image: url(https://example.com/using-background-image-stylesheet);
+            shape-outside: url(https://example.com/using-shape-outside-stylesheet);
+            filter: url(https://example.com/using-filter-stylesheet);
+            mask-image: url(https://example.com/using-mask-image-stylesheet);
+        }
+    </style>
+    <rect class="url" />
+
+    <style>
+        @font-face {
+            font-family: 'Test Font';
+            src: url(https://example.com/using-font-face.woff) format(woff), url(https://example.com/using-font-face.woff2) format(woff2);
+        }
+        text {
+            font-family: 'Test Font';
+        }
+    </style>
+    <text>Use developer tools to observe several requests to example.com</text>
+</svg>


### PR DESCRIPTION
### Resolves

https://scratchfoundation.atlassian.net/browse/UEPR-224

### Proposed Changes

Add stricter rules for svg url loading:
- make sure rules on removing tags are case-insensitive
- check <style> elements and remove url attributes
- check inlined style attributes and remove them if there is an external `url(..)` present

### Reason for Changes

There were reports of multiple ways to exploit svgs by including urls into them, which the browser then loads.

### Test Coverage

Added a test case with multiple ways of adding svg urls
